### PR TITLE
Fix incorrect file path

### DIFF
--- a/module.json
+++ b/module.json
@@ -16,7 +16,7 @@
 	],
 	"system": [ "dnd5e" ],
 	"esmodules": [
-		"./lib/libwrapper/shim.js",
+		"./lib/libWrapper/shim.js",
 		"./src/ready-set-roll.js",		
 		"./src/module/config.js"
 	],


### PR DESCRIPTION
Fixes an issue where the provided libWrapper directory was incorrectly capitalised. This caused issues with installation on some machines.