### PR TITLE
hotfix/negative-mod-values

### DIFF
--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -357,7 +357,7 @@ async function _addFieldDamage(fields, item, params) {
 
         let damageTermGroups = [];
         for (let i = 0; i < item.system.damage.parts.length; i++) {
-            const tmpRoll = new Roll(item.system.damage.parts[i][0]);
+            const tmpRoll = new CONFIG.Dice.DamageRoll(item.system.damage.parts[i][0], item.getRollData());
             const partTerms = roll.terms.splice(0, tmpRoll.terms.length);
             roll.terms.shift();
 


### PR DESCRIPTION
Fixes an issue where negative modifiers would break damage roll calculations for items. Closes #9.