### PR TITLE
hotfix/versatile-option-is-ignored

### DIFF
--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -61,8 +61,9 @@ export class ItemUtility {
         }                
         
         params = params ?? {};
+        params.damageFlags = ItemUtility.getFlagValueFromItem(item, "quickDamage", isAltRoll);
+        params.versatile = ItemUtility.getFlagValueFromItem(item, "quickVersatile", isAltRoll);
 
-        params.damageFlags = ItemUtility.getFlagValueFromItem(item, "quickDamage", isAltRoll)
         if (params.damageFlags) {
             await _addFieldDamage(fields, item, params);
         }


### PR DESCRIPTION
Fixes an issue where the setting of the versatile flag would not be passed to the damage rolls, and therefore be ignored.

Closes #11.