### PR TITLE
bugfix/consume-uses-not-in-config

### DIFF
--- a/src/utils/sheet.js
+++ b/src/utils/sheet.js
@@ -84,7 +84,7 @@ async function _addItemOptions(item, html) {
         combinedDamageTypes: CONFIG[`${MODULE_SHORT}`].combinedDamageTypes,
         hasFlavor: item.system.chatFlavor && item.system.chatFlavor !== "",
         hasDamage: item.hasDamage,
-        hasConsume: item.hasQuantity || item.hasUse || item.hasResource || item.hasRecharge,
+        hasConsume: item.hasQuantity || item.hasUses || item.hasResource || item.hasRecharge,
         hasQuantity: item.hasQuantity,
         hasUses: item.hasUses,
         hasResource: item.hasResource,


### PR DESCRIPTION
Fixes an issue where uses would not show in the roll configuration until another consumable is added.