### PR TITLE
bugfix/other-formula-not-rolling

### DIFF
--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -420,7 +420,7 @@ async function _addFieldDamage(fields, item, params) {
  */
 async function _addFieldOtherFormula(fields, item) {
     if (item.system.formula) {
-        const otherRoll = await new Roll(item.system.formula).roll({ async: true });
+        const otherRoll = await new Roll(item.system.formula, item.getRollData()).roll({ async: true });
 
         fields.push([
             FIELD_TYPE.DAMAGE,

--- a/src/utils/sheet.js
+++ b/src/utils/sheet.js
@@ -89,6 +89,7 @@ async function _addItemOptions(item, html) {
         hasUses: item.hasUses,
         hasResource: item.hasResource,
         hasRecharge: item.hasRecharge,
+        hasOther: item.system.formula ? true : false,
         isAttack: item.hasAttack,
         isSave: item.hasSave,
         isCheck: item.hasAbilityCheck || item.type === ITEM_TYPE.TOOL,

--- a/templates/rsr-item-options.html
+++ b/templates/rsr-item-options.html
@@ -92,6 +92,18 @@
 						{{localize "rsr5e.sheet.tab.options.template"}}
 					</label>
 					{{/if}}{{/if}}
+					{{#if flags.rsr5e.quickOther}} {{#if hasOther}}
+					<label class="checkbox">
+						<input
+							type="checkbox"
+							name="flags.rsr5e.quickOther.value"
+							value="flags.rsr5e.quickOther.value"
+							data-dtype="{{flags.rsr5e.quickOther.type}}"
+							{{checked flags.rsr5e.quickOther.value}}
+						/>
+						{{localize "rsr5e.sheet.tab.options.other"}}
+					</label>
+					{{/if}}{{/if}}
 					{{#if flags.rsr5e.quickVersatile}} {{#if isVersatile}}
 					<label class="checkbox">
 						<input
@@ -281,6 +293,18 @@
 							{{checked flags.rsr5e.quickTemplate.altValue}}
 						/>
 						{{localize "rsr5e.sheet.tab.options.template"}}
+					</label>
+					{{/if}}{{/if}}										
+					{{#if flags.rsr5e.quickOther}} {{#if hasOther}}
+					<label class="checkbox">
+						<input
+							type="checkbox"
+							name="flags.rsr5e.quickOther.altValue"
+							value="flags.rsr5e.quickOther.altValue"
+							data-dtype="{{flags.rsr5e.quickOther.type}}"
+							{{checked flags.rsr5e.quickOther.altValue}}
+						/>
+						{{localize "rsr5e.sheet.tab.options.other"}}
 					</label>
 					{{/if}}{{/if}}
 					{{#if flags.rsr5e.quickVersatile}} {{#if isVersatile}}


### PR DESCRIPTION
Fixes an issue where the "other" formula in items would not appear in the roll configuration, and would not be correctly rolled to a chat card.

Closes #15. 