### PR TITLE
bugfix/chat-card-toggle-content

### DIFF
--- a/src/module/templates.js
+++ b/src/module/templates.js
@@ -10,5 +10,6 @@ export const TEMPLATE = {
     MULTIROLL: "rsr-multiroll.html",
     DAMAGE: "rsr-damage-roll.html",
     SAVE_BUTTON: "rsr-save-button.html",
-    OPTIONS: "rsr-item-options.html"
+    OPTIONS: "rsr-item-options.html",
+    BLANK: "rsr-blank.html"
 }

--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -48,6 +48,10 @@ export class ItemUtility {
             _addFieldDescription(fields, chatData);
         }
 
+        if (!fields.some(f => f[0] === FIELD_TYPE.DESCRIPTION)) {
+            fields.push([FIELD_TYPE.BLANK, { display: false }]);
+        }
+
         if (ItemUtility.getFlagValueFromItem(item, "quickSave", isAltRoll)) {
             _addFieldSave(fields, item);
         }
@@ -321,6 +325,9 @@ async function _addFieldAttack(fields, item, params) {
             item.system.consume.type = "ammo";
         }
 
+        // Adds a seperator for UI clarity.
+        fields.push([FIELD_TYPE.BLANK, { display: true }]);
+
         fields.push([
             FIELD_TYPE.ATTACK,
             {
@@ -472,6 +479,9 @@ async function _addFieldAbilityCheck(fields, item, params) {
             disadvantage: params?.advMode < 0 ?? false
         });
 
+        // Adds a seperator for UI clarity.
+        fields.push([FIELD_TYPE.BLANK, { display: true }]);
+
         fields.push([
             FIELD_TYPE.ATTACK,
             {
@@ -480,5 +490,7 @@ async function _addFieldAbilityCheck(fields, item, params) {
                 title: `Ability Check - ${CONFIG.DND5E.abilities[item.hasAbilityCheck]}`
             }
         ]);
-    }    
+    }
+
+
 }

--- a/src/utils/render.js
+++ b/src/utils/render.js
@@ -16,7 +16,8 @@ export const FIELD_TYPE = {
     CHECK: 'check',
     ATTACK: 'attack',
     DAMAGE: 'damage',
-    SAVE: 'save'
+    SAVE: 'save',
+    BLANK: 'blank'
 }
 
 /**
@@ -28,33 +29,44 @@ export class RenderUtility {
         fieldData = mergeObject(metadata, fieldData ?? {}, { recursive: false });
 
         switch (fieldType) {
+            case FIELD_TYPE.BLANK:
+                return _renderBlank(fieldData);
             case FIELD_TYPE.HEADER:
-                return renderHeader(fieldData);
+                return _renderHeader(fieldData);
             case FIELD_TYPE.FOOTER:
-                return renderFooter(fieldData);
+                return _renderFooter(fieldData);
             case FIELD_TYPE.DESCRIPTION:
-                return renderDescription(fieldData);
+                return _renderDescription(fieldData);
             case FIELD_TYPE.SAVE:
-                return renderSaveButton(fieldData);
+                return _renderSaveButton(fieldData);
             case FIELD_TYPE.CHECK:
-                return await renderMultiRoll(fieldData);
+                return await _renderMultiRoll(fieldData);
             case FIELD_TYPE.ATTACK:
-                return await renderAttackRoll(fieldData);
+                return await _renderAttackRoll(fieldData);
             case FIELD_TYPE.DAMAGE:
-                return await renderDamageRoll(fieldData);
+                return await _renderDamageRoll(fieldData);
         }
     }
 
     static renderFullCard(props) {
-        return renderModuleTemplate(TEMPLATE.FULL_CARD, props);
+        return _renderModuleTemplate(TEMPLATE.FULL_CARD, props);
     }
 
     static renderItemOptions(props) {
-        return renderModuleTemplate(TEMPLATE.OPTIONS, props);
+        return _renderModuleTemplate(TEMPLATE.OPTIONS, props);
     }
 }
 
-function renderHeader(renderData = {}) {
+function _renderBlank(renderData = {}) {
+    const { id, display } = renderData;
+
+    return _renderModuleTemplate(TEMPLATE.BLANK, {
+        id,
+        display
+    });
+}
+
+function _renderHeader(renderData = {}) {
     const { id, item, slotLevel } = renderData;
     const actor = renderData?.actor ?? item?.actor;
     const img = renderData.img ?? item?.img ?? CoreUtility.getActorImage(actor);
@@ -69,36 +81,36 @@ function renderHeader(renderData = {}) {
         title += ` (${CONFIG.DND5E.abilities[item.system.ability]})`;
     }
 
-    return renderModuleTemplate(TEMPLATE.HEADER, {
+    return _renderModuleTemplate(TEMPLATE.HEADER, {
         id,
         item: { img: img ?? DEFAULT_IMG, name: title },
         slotLevel
     });
 }
 
-function renderFooter(renderData = {}) {
+function _renderFooter(renderData = {}) {
     const { properties } = renderData;
 
-    return renderModuleTemplate(TEMPLATE.FOOTER, {
+    return _renderModuleTemplate(TEMPLATE.FOOTER, {
         properties
     });
 }
 
-function renderDescription(renderData = {}) {
+function _renderDescription(renderData = {}) {
     const { content, isFlavor } = renderData;
 
-    return renderModuleTemplate(TEMPLATE.DESCRIPTION, {
+    return _renderModuleTemplate(TEMPLATE.DESCRIPTION, {
         content,
         isFlavor
     });
 }
 
-function renderSaveButton(renderData = {}) {
+function _renderSaveButton(renderData = {}) {
     const { id, ability, dc, hideDC } = renderData;    
 
     const abilityLabel = CONFIG.DND5E.abilities[ability];
 
-    return renderModuleTemplate(TEMPLATE.SAVE_BUTTON, {
+    return _renderModuleTemplate(TEMPLATE.SAVE_BUTTON, {
         id,
         ability,
         abilityLabel,
@@ -107,7 +119,7 @@ function renderSaveButton(renderData = {}) {
     });
 }
 
-async function renderMultiRoll(renderData = {}) {
+async function _renderMultiRoll(renderData = {}) {
     const { id, roll, title } = renderData;
     const entries = [];
 
@@ -147,7 +159,7 @@ async function renderMultiRoll(renderData = {}) {
     const tooltips = await Promise.all(entries.map(e => e.roll.getTooltip()));
     const bonusTooltip = await bonusRoll?.getTooltip();
 
-    return renderModuleTemplate(TEMPLATE.MULTIROLL, {
+    return _renderModuleTemplate(TEMPLATE.MULTIROLL, {
         id,
         title,
         formula: roll.formula,
@@ -157,7 +169,7 @@ async function renderMultiRoll(renderData = {}) {
     });
 }
 
-async function renderAttackRoll(renderData = {}) {
+async function _renderAttackRoll(renderData = {}) {
     const { consume } = renderData;
 
     const title = renderData.title ??
@@ -165,10 +177,10 @@ async function renderAttackRoll(renderData = {}) {
 
     renderData = mergeObject({ title }, renderData ?? {}, { recursive: false });
 
-    return renderMultiRoll(renderData);
+    return _renderMultiRoll(renderData);
 }
 
-async function renderDamageRoll(renderData = {}) {
+async function _renderDamageRoll(renderData = {}) {
     const { id, damageType, baseRoll, critRoll, context, versatile } = renderData;
     
     // If there's no content in the damage roll, silently end rendering the field.
@@ -229,7 +241,7 @@ async function renderDamageRoll(renderData = {}) {
         critRoll?.getTooltip()
     ])).filter(t => t);
 
-    return renderModuleTemplate(TEMPLATE.DAMAGE, {
+    return _renderModuleTemplate(TEMPLATE.DAMAGE, {
         id,        
         damageRollType: ROLL_TYPE.DAMAGE,
         tooltips,
@@ -250,7 +262,7 @@ async function renderDamageRoll(renderData = {}) {
  * @param {Object} props The props data to render the template with.
  * @returns {Promise<string>} A rendered html template.
  */
-function renderModuleTemplate(template, props) {
+function _renderModuleTemplate(template, props) {
     return renderTemplate(`modules/${MODULE_NAME}/templates/${template}`, props);
 }
 

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -247,6 +247,7 @@ async function getActorRoll(actor, title, roll, rollType, createMessage = true) 
         },
         [
             [FIELD_TYPE.HEADER, { title }],
+            [FIELD_TYPE.BLANK, { display: false }],
             [FIELD_TYPE.CHECK, { roll, rollType }]
         ]
     );

--- a/templates/rsr-blank.html
+++ b/templates/rsr-blank.html
@@ -1,0 +1,5 @@
+{{#if display}}
+<div class="card-content" style="display: block;"></div>
+{{else}}
+<div class="card-content" style="display: none;"></div>
+{{/if}}


### PR DESCRIPTION
Fixes an issue with cards that don't have a description in the chat card where clicking the header would output an error. While this didn't technically break anything, this solution should prevent the log from being spammed with errors.

Closes #17.