### PR TITLE
bugfix/d20-rolls-not-in-chat-message

### DIFF
--- a/src/utils/patching.js
+++ b/src/utils/patching.js
@@ -38,6 +38,9 @@ export class PatchingUtility {
         }
     }
 
+    /**
+     * Patches item sheets: quick roll configuration tabs, and damage context fields.
+     */
     static patchItemSheets() {        
         LogUtility.log("Patching Item Sheets");
         const itemSheetPrototype = "ItemSheet.prototype";


### PR DESCRIPTION
Includes D20 dice into the chat message data so that modules that pick up on it to do other things (e.g. Dice So Nice) can use it appropriately. Did some trickery here to ensure that D20 values that aren't damage aren't actually added to the "total damage" value when using apply damage context menu.

Closes #18.