### PR TITLE
bugfix/customizing-crit-damage

### DIFF
--- a/src/module/quickroll.js
+++ b/src/module/quickroll.js
@@ -252,11 +252,12 @@ export class QuickRoll {
 		const options = {
 			multiplyNumeric: game.settings.get("dnd5e", "criticalDamageModifiers"),
 			powerfulCritical: game.settings.get("dnd5e", "criticalDamageMaxDice"),
-			criticalBonusDice: this.item.system.actionType === "mwak" ? (this.actor.getFlag("dnd5e", "meleeCriticalDamageDice") ?? 0) : 0
+			criticalBonusDice: this.item.system.actionType === "mwak" ? (this.actor.getFlag("dnd5e", "meleeCriticalDamageDice") ?? 0) : 0,
+			criticalBonusDamage: this.item.system.critical.damage ?? ""
 		}
-
+		
 		const damageFields = this.fields.filter(f => f[0] === FIELD_TYPE.DAMAGE);
-		targetField[1].critRoll = await RollUtility.getCritRoll(targetField[1].baseRoll, damageFields.indexOf(targetField), options);
+		targetField[1].critRoll = await RollUtility.getCritRoll(targetField[1].baseRoll, damageFields.indexOf(targetField), this.item.getRollData(), options);
 
 		return true;
 	}

--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -391,7 +391,7 @@ async function _addFieldDamage(fields, item, params) {
             
             let critRoll = null;
             if (params?.isCrit) {
-                critRoll = await RollUtility.getCritRoll(baseRoll, i, roll.options, params);
+                critRoll = await RollUtility.getCritRoll(baseRoll, i, item.getRollData(), roll.options);
             }
 
             fields.push([

--- a/src/utils/render.js
+++ b/src/utils/render.js
@@ -280,6 +280,13 @@ async function _renderDamageRoll(renderData = {}) {
         critRoll?.getTooltip()
     ])).filter(t => t);
 
+    // Generate a formula string that displays rolled crit damage as well.
+    let formula = baseRoll?.formula ?? "";    
+    if (baseRoll?.formula && critRoll?.formula) {
+        formula = formula.concat(" + ");
+    }
+    formula += critRoll?.formula ?? "";
+
     return _renderModuleTemplate(TEMPLATE.DAMAGE, {
         id,        
         damageRollType: ROLL_TYPE.DAMAGE,
@@ -290,7 +297,7 @@ async function _renderDamageRoll(renderData = {}) {
         damagetop: labels[1],
         damagemid: labels[2],
         damagebottom: labels[3],
-        formula: baseRoll?.formula ?? critRoll.formula,
+        formula,
         damageType,
     });
 }


### PR DESCRIPTION
Fixes some issues with crit damage where item specific bonus damage and modifiers for dice would be ignored when rolling critical damage. Quick rolls should now correctly display the rolled critical damage in its entirety, and correctly take into account bonus damage. The formula for rolled critical damage will also be correctly displayed in the card.

Closes #56.