### PR TITLE
Add options for applying damage

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -17,6 +17,8 @@
             "enableOverlayButtons.hint": "When outputting a quick roll, enable overlay buttons on the chat message that offer additional functionality for the roll.",
             "alwaysApplyCrit.name": "Always Apply Critical Damage",
             "alwaysApplyCrit.hint": "When using damage overlay buttons, always apply the rolled critical damage (if any). If turned off, using an overlay button for critical damage will display a prompt allowing the user to choose.",
+            "applyDamageTo.name": "Apply Damage Options",
+            "applyDamageTo.hint": "Determines which tokens damage is applied to when applying damage via the chat overlay buttons.",
             "alwaysRollMulti.name": "Always Roll Multiple Dice",
             "alwaysRollMulti.hint": "When outputting a quick roll, always roll two dice (or three for Elven Accuracy) even when advantage/disadvantage is not applied.",
             "showSkillAbilities.name": "Show Ability Names for Skills",
@@ -38,8 +40,7 @@
             "contextReplacesDamage.name": "Context Replaces Damage Type",
             "contextReplacesDamage.hint": "If a context label is in the same place as a damage type label, it will replace it.",
             "hideSaveDC.name": "Hide Save DCs",
-            "hideSaveDC.hint": "Determines if the DC is hidden on save DC buttons for quick rolls.",
-            "hideSaveDC.replacement": "??"
+            "hideSaveDC.hint": "Determines if the DC is hidden on save DC buttons for quick rolls."
         },
         "messages": {
             "error": {
@@ -65,6 +66,11 @@
                 "1": "Above",
                 "2": "Below & Inside",
                 "3": "Below & Outside"
+            },
+            "apply": {
+                "0": "Apply to Selected Tokens",
+                "1": "Apply to Targeted Tokens",
+                "2": "Apply to Both"
             },
             "hideSaveDC": {
                 "0": "Never",
@@ -105,6 +111,7 @@
             }
         },
         "chat": {
+            "hide": "??",
             "attack": "Attack",
             "check": "Check",
             "save": "Save",

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -16,6 +16,7 @@ export const SETTING_NAMES = {
     DICE_SOUNDS_ENABLED: "enableDiceSounds",
     OVERLAY_BUTTONS_ENABLED: "enableOverlayButtons",
     ALWAYS_APPLY_CRIT: "alwaysApplyCrit",
+    APPLY_DAMAGE_TO: "applyDamageTo",
     PLACEMENT_ROLL_TITLE: "placementRollTitle",
     PLACEMENT_DAMAGE_TITLE: "placementDamageTitle",
     PLACEMENT_DAMAGE_CONTEXT: "placementDamageContext",
@@ -53,56 +54,71 @@ export class SettingsUtility {
 
         // QUICK ROLL SETTINGS        
 		const quickRollOptions = [
-            SETTING_NAMES.QUICK_ABILITY_ENABLED,
-            SETTING_NAMES.QUICK_SKILL_ENABLED,
-            SETTING_NAMES.QUICK_ITEM_ENABLED
+            { name: SETTING_NAMES.QUICK_ABILITY_ENABLED, default: true },
+            { name: SETTING_NAMES.QUICK_SKILL_ENABLED, default: true },
+            { name: SETTING_NAMES.QUICK_ITEM_ENABLED, default: true }
         ];
 
         quickRollOptions.forEach(option => {
-            game.settings.register(MODULE_NAME, option, {
-                name: CoreUtility.localize(`${MODULE_SHORT}.settings.${option}.name`),
-                hint: CoreUtility.localize(`${MODULE_SHORT}.settings.${option}.hint`),
+            game.settings.register(MODULE_NAME, option.name, {
+                name: CoreUtility.localize(`${MODULE_SHORT}.settings.${option.name}.name`),
+                hint: CoreUtility.localize(`${MODULE_SHORT}.settings.${option.name}.hint`),
                 scope: "world",
                 config: true,
                 type: Boolean,
-                default: true,
+                default: option.default,
                 requiresReload: true
             });
         });
 
         // ADDITIONAL ROLL SETTINGS
         const extraRollOptions = [
-            SETTING_NAMES.ALT_ROLL_ENABLED,
-            SETTING_NAMES.ALWAYS_ROLL_MULTIROLL
+            { name: SETTING_NAMES.ALT_ROLL_ENABLED, default: false },
+            { name: SETTING_NAMES.ALWAYS_ROLL_MULTIROLL, default: false }
         ];
 
         extraRollOptions.forEach(option => {
-            game.settings.register(MODULE_NAME, option, {
-                name: CoreUtility.localize(`${MODULE_SHORT}.settings.${option}.name`),
-                hint: CoreUtility.localize(`${MODULE_SHORT}.settings.${option}.hint`),
+            game.settings.register(MODULE_NAME, option.name, {
+                name: CoreUtility.localize(`${MODULE_SHORT}.settings.${option.name}.name`),
+                hint: CoreUtility.localize(`${MODULE_SHORT}.settings.${option.name}.hint`),
                 scope: "world",
                 config: true,
                 type: Boolean,
-                default: false,
+                default: option.default,
             });
         });
 
         // OVERLAY BUTTON OPTIONS
         const overlayOptions = [
-            SETTING_NAMES.OVERLAY_BUTTONS_ENABLED,
-            SETTING_NAMES.ALWAYS_APPLY_CRIT
+            { name: SETTING_NAMES.OVERLAY_BUTTONS_ENABLED, default: true },
+            { name: SETTING_NAMES.ALWAYS_APPLY_CRIT, default: true }
         ]        
 
         overlayOptions.forEach(option => {
-            game.settings.register(MODULE_NAME, option, {
-                name: CoreUtility.localize(`${MODULE_SHORT}.settings.${option}.name`),
-                hint: CoreUtility.localize(`${MODULE_SHORT}.settings.${option}.hint`),
+            game.settings.register(MODULE_NAME, option.name, {
+                name: CoreUtility.localize(`${MODULE_SHORT}.settings.${option.name}.name`),
+                hint: CoreUtility.localize(`${MODULE_SHORT}.settings.${option.name}.hint`),
                 scope: "world",
                 config: true,
                 type: Boolean,
-                default: true,
+                default: option.default,
                 requiresReload: true
             });
+        });
+        
+        game.settings.register(MODULE_NAME, SETTING_NAMES.APPLY_DAMAGE_TO, {
+            name: CoreUtility.localize(`${MODULE_SHORT}.settings.${SETTING_NAMES.APPLY_DAMAGE_TO}.name`),
+            hint: CoreUtility.localize(`${MODULE_SHORT}.settings.${SETTING_NAMES.APPLY_DAMAGE_TO}.hint`),
+            scope: "world",
+            config: true,
+            type: Number,
+            default: 0,
+            requiresReload: true,
+            choices: {
+                0: CoreUtility.localize(`${MODULE_SHORT}.choices.apply.0`),
+                1: CoreUtility.localize(`${MODULE_SHORT}.choices.apply.1`),
+                2: CoreUtility.localize(`${MODULE_SHORT}.choices.apply.2`)
+            }
         });
 
         game.settings.register(MODULE_NAME, SETTING_NAMES.SHOW_SKILL_ABILITIES, {


### PR DESCRIPTION
Adds a requested feature that allows damage to be applied to either selected or targeted tokens, or both. This can be changed via a module setting.

Closes #45 and #55.