### PR TITLE
hotfix/fix-consumable-duplication

### DIFF
--- a/src/module/quickroll.js
+++ b/src/module/quickroll.js
@@ -144,7 +144,7 @@ export class QuickRoll {
 			const storedData = message.getFlag("dnd5e", "itemData");
 			const Item5e = game.dnd5e.documents.Item5e;
 
-			roll.item = storedData && roll.actor ? Item5e.create(storedData) : roll.actor?.items.get(data.itemId);
+			roll.item = storedData && roll.actor ? Item5e.create(storedData, { temporary: true }) : roll.actor?.items.get(data.itemId);
 		}
 		
 		return roll;


### PR DESCRIPTION
Fix an issue where destroyed consumable items would get recreated into the items tab instead of in a temporary manner.

Closes #78.