### PR TITLE
hotfix/retroactive-elven-accuracy

### DIFF
--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -413,10 +413,11 @@ async function _getItemRoll(item, params, rollType, createMessage = true) {
     const isFumble = params?.isFumble ?? false;
     const isMultiRoll = params?.isMultiRoll ?? false;
     const isAltRoll = params?.isAltRoll ?? false;
+    const elvenAccuracy = params?.elvenAccuracy ?? false;
 
     const quickroll = new QuickRoll(
         item,
-        { hasAdvantage, hasDisadvantage, isCrit, isFumble, isMultiRoll, isAltRoll },
+        { hasAdvantage, hasDisadvantage, isCrit, isFumble, isMultiRoll, isAltRoll, elvenAccuracy },
         [
             [FIELD_TYPE.HEADER, { title: item.name, slotLevel: params?.slotLevel }],
             ...itemFields


### PR DESCRIPTION
Fix an issue where retroactive advantage would not roll elven accuracy correctly.

Closes #86.