### PR TITLE
bugfix/cub-concentrator

### DIFF
--- a/src/module/quickroll.js
+++ b/src/module/quickroll.js
@@ -167,7 +167,7 @@ export class QuickRoll {
 			speaker: ChatMessage.getSpeaker({ item, actor }),
 			flags: this._getFlags(),
 			type: CONST.CHAT_MESSAGE_TYPES.ROLL,
-			roll: this._getChatMessageRolls(),
+			rolls: this._getChatMessageRolls(),
 			...CoreUtility.getRollSound(),
 			...CoreUtility.getWhisperData(rollMode),
 		}
@@ -378,10 +378,10 @@ export class QuickRoll {
 	 * @private
 	 */
 	_getChatMessageRolls() {
-		let roll = new Roll("1d0").evaluate({ async: false });
+		const rolls = [];
 	
         if (this.fields.length === 0) {
-            return roll;
+            return rolls;
         }
 		
 		// If we need to add damage that has no die rolls in it, we have to add a safety die with no value.
@@ -407,19 +407,20 @@ export class QuickRoll {
 
 		// Damage rolls must be added first into index 0 for applyChatCardDamage() to work.
 		if (terms.length !== 0) {
-            roll = Roll.fromTerms(Roll.simplifyTerms(terms));
-			roll.terms.unshift(safety, plus);
+            const damageRoll = Roll.fromTerms(Roll.simplifyTerms(terms));
+			damageRoll.terms.unshift(safety, plus);
+
+			rolls.push(damageRoll);
         }
 
-		// Add in dice for d20 rolls.
+		// Add in d20 rolls.
 		const rollFields = this.fields.filter(f => f[0] === FIELD_TYPE.CHECK || f[0] === FIELD_TYPE.ATTACK).map(f => f[1]);
 
 		rollFields.forEach(field => {
-			roll.terms.push(plus);
-			roll.terms.push(...field.roll.dice);
+			rolls.push(field.roll);
 		});
-		
-		return roll;
+
+		return rolls;
 	}
 }
 


### PR DESCRIPTION
Fixes how rolls are stored in chat cards to use the roll array introduced in Foundry V10 instead of trying to combine everything into 1 roll. This fixes a variety of issues, but most crucially allows other modules to access the roll total from the chat card, example for Combat Utility Belt's concentrator.

Closes #93.