### PR TITLE
bugfix/damage-type-error

### DIFF
--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -433,7 +433,7 @@ async function _addFieldDamage(fields, item, params) {
 
         let damageTermGroups = [];
         item.system.damage.parts.forEach((part, i) => {
-            const tmpRoll = new CONFIG.Dice.DamageRoll(part[0], item.getRollData());
+            const tmpRoll = new CONFIG.Dice.DamageRoll(part[0], item.getRollData()).evaluate({ async: false });
             const partTerms = roll.terms.splice(0, tmpRoll.terms.length);
             roll.terms.shift();
 


### PR DESCRIPTION
Fixes an issue where more complex damage formulae had term mismatches due to damage type or variable strings. The temporary roll used to separate damage rolls now is evaluated to ensure terms are on par with the rolled damage.

Closes #102.