### PR TITLE
bugfix/incorrect-context-indexing

### DIFF
--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -432,6 +432,7 @@ async function _addFieldDamage(fields, item, params) {
         });
 
         let damageTermGroups = [];
+        let damageContextGroups = [];
         item.system.damage.parts.forEach((part, i) => {
             const tmpRoll = new CONFIG.Dice.DamageRoll(part[0], item.getRollData()).evaluate({ async: false });
             const partTerms = roll.terms.splice(0, tmpRoll.terms.length);
@@ -439,6 +440,7 @@ async function _addFieldDamage(fields, item, params) {
 
             if (params?.damageFlags[i] ?? true) {
                 damageTermGroups.push({ type: part[1], terms: partTerms});
+                damageContextGroups.push(ItemUtility.getDamageContextFromItem(item, i));
             }
         });
 
@@ -462,7 +464,7 @@ async function _addFieldDamage(fields, item, params) {
                     damageType: group.type,
                     baseRoll,
                     critRoll,
-                    context: ItemUtility.getDamageContextFromItem(item, i),
+                    context: damageContextGroups[i],
                     versatile: i !== 0 ? false : params?.versatile ?? false
                 }
             ]);


### PR DESCRIPTION
Fixes an issue where damage rolls would use the incorrect context if some previous damage fields were disabled in the quick roll config.

Closes #106.