### PR TITLE
bugfix/unlinked-token-damage

### DIFF
--- a/src/module/quickroll.js
+++ b/src/module/quickroll.js
@@ -136,7 +136,10 @@ export class QuickRoll {
 
 		roll.messageId = message.id
 
-		if (data?.actorId) {
+		if (data?.tokenId) {
+			const token = await fromUuid(data.tokenId);
+			roll.actor = token?.actor;
+		} else if (data?.actorId) {
 			roll.actor = game.actors.get(data.actorId);
 		}
 


### PR DESCRIPTION
Fixes an issue where unlinked tokens that had new items added to them would not correctly roll manual damage. This was due to the token attempting to fetch the item from the original actor prototype, rather than using the actor instance attached to the token.

Closes #111.