### PR TITLE
feature/quick-roll-descriptions-default

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -9,6 +9,8 @@
             "enableItemQuickRoll.hint": "When clicking on an item's image (weapons, spells, features, etc.), automatically roll to chat instead of using the normal chat output. This functionality can be bypassed by holding Alt when clicking.",
             "enableAltQuickRoll.name": "Enable Alternate Roll for Items",
             "enableAltQuickRoll.hint": "When Alt-clicking on an item's image, output a different quick roll which can be configured separately, replacing the ability to bypass quick rolling for items. This setting has no effect if item quick rolling is disabled.",
+            "enableQuickRollDesc.name": "Enable Descriptions by Default",
+            "enableQuickRollDesc.hint": "When outputting a quick roll, always show the description by default. This can still be changed per item in quick roll configuration.",
             "enableD20Icons.name": "Show D20 Rolls for Quick Rolls",
             "enableD20Icons.hint": "When outputting a quick roll, display an icon showing the natural die roll next to the total result.",
             "enableDiceSounds.name": "Enable Dice Sounds for Quick Rolls",

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -1,5 +1,6 @@
 import { ITEM_TYPE } from "../utils/item.js";
 import { FIELD_TYPE } from "../utils/render.js";
+import { SettingsUtility, SETTING_NAMES } from "../utils/settings.js";
 import { MODULE_SHORT } from "./const.js";
 
 /**
@@ -31,7 +32,7 @@ CONFIG[MODULE_SHORT] = {
     },
     flags: {
         weapon: {
-			quickDesc: { type: "Boolean", value: false, altValue: false },
+			quickDesc: { type: "Boolean", get value() { return SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_ROLL_DESC_ENABLED) }, altValue: false },
 			quickFlavor: { type: "Boolean", value: true, altValue: true },
 			quickFooter: { type: "Boolean", value: true, altValue: true },
 			quickAttack: { type: "Boolean", value: true, altValue: true },
@@ -83,7 +84,7 @@ CONFIG[MODULE_SHORT] = {
             consumeRecharge: { type: "Boolean", value: true, altValue: true }
         },
         tool: {
-            quickDesc: { type: "Boolean", value: false, altValue: false },
+			quickDesc: { type: "Boolean", get value() { return SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_ROLL_DESC_ENABLED) }, altValue: false },
             quickFlavor: { type: "Boolean", value: true, altValue: true },
             quickFooter: { type: "Boolean", value: true, altValue: true },
             quickCheck: { type: "Boolean", value: true, altValue: true }

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -12,6 +12,7 @@ export const SETTING_NAMES = {
     QUICK_ABILITY_ENABLED: "enableAbilityQuickRoll",
     QUICK_ITEM_ENABLED: "enableItemQuickRoll",
     ALT_ROLL_ENABLED: "enableAltQuickRoll",
+    QUICK_ROLL_DESC_ENABLED: "enableQuickRollDesc",
     D20_ICONS_ENABLED: "enableD20Icons",
     DICE_SOUNDS_ENABLED: "enableDiceSounds",
     OVERLAY_BUTTONS_ENABLED: "enableOverlayButtons",
@@ -75,6 +76,7 @@ export class SettingsUtility {
         // ADDITIONAL ROLL SETTINGS
         const extraRollOptions = [
             { name: SETTING_NAMES.ALT_ROLL_ENABLED, default: false, scope: "world" },
+            { name: SETTING_NAMES.QUICK_ROLL_DESC_ENABLED, default: false, scope: "world" },
             { name: SETTING_NAMES.ALWAYS_ROLL_MULTIROLL, default: false, scope: "client"  },
             { name: SETTING_NAMES.ALWAYS_MANUAL_DAMAGE, default: false, scope: "client"  }
         ];


### PR DESCRIPTION
Adds a setting to enable descriptions for all quick rolls by default. Fixes #109.