### PR TITLE
bugfix/spell-consume-config-fix

### DIFF
--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -177,7 +177,12 @@ export class ItemUtility {
      * These booleans give a quick indication on if the item has that specific consume property.
      * @param {Item} item The item on which to ensure consume properties exist.
      */
-    static ensureConsumePropertiesOnItem(item) {
+    static ensureConsumePropertiesOnItem(item) {        
+        if (item?.type === ITEM_TYPE.SPELL)
+        {
+            return;
+        }
+
         if (item) {
             // For items with quantity (weapons, tools, consumables...)
             item.hasQuantity = ("quantity" in item.system);


### PR DESCRIPTION
Ensures that spells don't get consumable flags since the intent is for spell consumes to be calculated by the pop-up config when casting.

Fixes #123.