### PR TITLE
bugfix/crit-threshold-colouring

### DIFF
--- a/css/ready-set-roll.css
+++ b/css/ready-set-roll.css
@@ -33,6 +33,14 @@
 	padding: 0px 4px 0px 4px;
 }
 
+.dice-roll .dice-total.critical {
+	color: var(--color-text-dark-primary);
+}
+
+.dice-roll .dice-total.fumble {
+	color: var(--color-text-dark-primary);
+}
+
 .rsr-dual .dice-row .failure {
 	color: #aa0200;
 }

--- a/src/utils/render.js
+++ b/src/utils/render.js
@@ -178,8 +178,10 @@ async function _renderMultiRoll(renderData = {}) {
         if (roll.options.halflingLucky && d20Rolls.results[i].result === 1) {
             i++;
             tmpResults.push(d20Rolls.results[i]);
-        }
+        }        
         
+        let critOptions = { critThreshold: roll.options.critical, fumbleThreshold: roll.options.fumble };
+
         // Die terms must have active results or the base roll total of the generated roll is 0.
         // This does not apply to dice that have been rerolled (unless they are replaced by a fixer value eg. for reliable talent).
         tmpResults.forEach(r => {
@@ -198,7 +200,7 @@ async function _renderMultiRoll(renderData = {}) {
 			roll: baseRoll,
 			total: baseRoll.total + (bonusRoll?.total ?? 0),
 			ignored: tmpResults.some(r => r.discarded) ? true : undefined,
-			critType: RollUtility.getCritTypeForDie(baseTerm),
+			critType: RollUtility.getCritTypeForDie(baseTerm, critOptions),
             d20Result: SettingsUtility.getSettingValue(SETTING_NAMES.D20_ICONS_ENABLED) ? d20Rolls.results[i].result : null
 		});
     }


### PR DESCRIPTION
Fixes an issue with crits from a lower crit threshold than 20 not being correctly formatted. Fixes an issue where Foundry was by default colouring crits and fumbles green and red respectively. This interfered with RSR's colouring and has been overridden.