### PR TITLE
feature/hide-save-dc

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -44,7 +44,7 @@
             "contextReplacesDamage.name": "Context Replaces Damage Type",
             "contextReplacesDamage.hint": "If a context label is in the same place as a damage type label, it will replace it.",
             "hideSaveDC.name": "Hide Save DCs",
-            "hideSaveDC.hint": "Determines if the DC is hidden on save DC buttons for quick rolls."
+            "hideSaveDC.hint": "Determines when to hide the value of the DC for saving throw buttons in quick rolls."
         },
         "messages": {
             "error": {

--- a/src/module/quickcard.js
+++ b/src/module/quickcard.js
@@ -34,6 +34,11 @@ export class QuickCard {
         this.speaker = game.actors.get(message.speaker.actor);
         this.id = message.id;
 
+        // Hide Save DCs
+        if (!(this.roll?.hasPermission ?? false)) {
+            html.find(".hideSave").text(CoreUtility.localize(`${MODULE_SHORT}.chat.hide`));
+        }
+
         if (SettingsUtility.getSettingValue(SETTING_NAMES.ALWAYS_MANUAL_DAMAGE)) {
             this._setupActionButtons(html);
             LogUtility.log("Initialised quick card action buttons.")

--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -340,14 +340,14 @@ function _addFieldFooter(fields, chatData) {
  */
 function _addFieldSave(fields, item) {
     if (item.hasSave) {
-        //const hideDCSetting = SettingsUtility.getSettingValue(SETTING_NAMES.HIDE_SAVE_DC);
+        const hideDCSetting = SettingsUtility.getSettingValue(SETTING_NAMES.HIDE_SAVE_DC);
 
         fields.push([
             FIELD_TYPE.SAVE,
             {
                 ability: item.system.save.ability,
                 dc: item.system.save.dc,
-                //hideDC: (hideDCSetting === 2 || (hideDCSetting === 1 && item.actor.type === "npc"))
+                hideDC: (hideDCSetting === 2 || (hideDCSetting === 1 && item.actor.type === "npc"))
             }
         ]);
     }

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -220,19 +220,19 @@ export class SettingsUtility {
 			}
 		});
 
-        // game.settings.register(MODULE_NAME, SETTING_NAMES.HIDE_SAVE_DC, {
-		// 	name: CoreUtility.localize(`${MODULE_SHORT}.settings.${SETTING_NAMES.HIDE_SAVE_DC}.name`),
-		// 	hint: CoreUtility.localize(`${MODULE_SHORT}.settings.${SETTING_NAMES.HIDE_SAVE_DC}.hint`),
-		// 	scope: "world",
-		// 	config: true,
-		// 	type: Number,
-		// 	default: 1,
-		// 	choices: {
-		// 		0: CoreUtility.localize(`${MODULE_SHORT}.choices.${SETTING_NAMES.HIDE_SAVE_DC}.0`),
-		// 		1: CoreUtility.localize(`${MODULE_SHORT}.choices.${SETTING_NAMES.HIDE_SAVE_DC}.1`),
-        //      2: CoreUtility.localize(`${MODULE_SHORT}.choices.${SETTING_NAMES.HIDE_SAVE_DC}.2`)
-		// 	}
-		// });
+        game.settings.register(MODULE_NAME, SETTING_NAMES.HIDE_SAVE_DC, {
+			name: CoreUtility.localize(`${MODULE_SHORT}.settings.${SETTING_NAMES.HIDE_SAVE_DC}.name`),
+			hint: CoreUtility.localize(`${MODULE_SHORT}.settings.${SETTING_NAMES.HIDE_SAVE_DC}.hint`),
+			scope: "world",
+			config: true,
+			type: Number,
+			default: 0,
+			choices: {
+				0: CoreUtility.localize(`${MODULE_SHORT}.choices.${SETTING_NAMES.HIDE_SAVE_DC}.0`),
+				1: CoreUtility.localize(`${MODULE_SHORT}.choices.${SETTING_NAMES.HIDE_SAVE_DC}.1`),
+                2: CoreUtility.localize(`${MODULE_SHORT}.choices.${SETTING_NAMES.HIDE_SAVE_DC}.2`)
+			}
+		});
     }
     
     /**


### PR DESCRIPTION
Adds the option for hiding the value of saving throw DCs for NPCs or always. This will replace the numerical value of a save DC with a "??" in the case that the roll is an NPC or not owned by the player respectively. GMs see all values always.

Fixes #101.