### PR TITLE
bugfix/auto-height-on-sheet

### DIFF
--- a/src/utils/sheet.js
+++ b/src/utils/sheet.js
@@ -50,7 +50,9 @@ export class SheetUtility {
             _activate = false;
         }
         
-        SheetUtility.setAutoHeightOnSheet(sheet);
+        if  (sheet._tabs[0].active === MODULE_SHORT) {
+            SheetUtility.setAutoHeightOnSheet(sheet);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes an issue where changing fields in details would scroll the sheet back to top due to auto-height enforcement.

Fixes #131.