### PR TITLE
feature/passthrough-roll-mode-for-actor-rolls

### DIFF
--- a/src/utils/patching.js
+++ b/src/utils/patching.js
@@ -63,7 +63,7 @@ async function _actorRollSkill(wrapper, skillId, options) {
     options = foundry.utils.mergeObject({ event: window.event }, options, { recursive: false });
     const { roll, ignore } = await _actorProcessWrapper(this, wrapper, options, skillId);
 
-    return ignore ? roll : RollUtility.rollSkill(this, skillId, roll);
+    return ignore ? roll : RollUtility.rollSkill(this, skillId, roll, options);
 }
 
 /**
@@ -78,7 +78,7 @@ async function _actorRollAbilityTest(wrapper, abilityId, options) {
     options = foundry.utils.mergeObject({ event: window.event }, options, { recursive: false });
     const { roll, ignore } = await _actorProcessWrapper(this, wrapper, options, abilityId);
 
-    return ignore ? roll : RollUtility.rollAbilityTest(this, abilityId, roll);
+    return ignore ? roll : RollUtility.rollAbilityTest(this, abilityId, roll, options);
 }
 
 /**
@@ -93,7 +93,7 @@ async function _actorRollAbilitySave(wrapper, abilityId, options) {
     options = foundry.utils.mergeObject({ event: window.event }, options, { recursive: false });
     const { roll, ignore } = await _actorProcessWrapper(this, wrapper, options, abilityId);
 
-    return ignore ? roll : RollUtility.rollAbilitySave(this, abilityId, roll);
+    return ignore ? roll : RollUtility.rollAbilitySave(this, abilityId, roll, options);
 }
 
 /**

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -61,7 +61,8 @@ export class RollUtility {
             fastForward: !bypass,
             chatMessage: bypass,
             advantage: advMode > 0,
-            disadvantage: advMode < 0
+            disadvantage: advMode < 0,
+            rollMode: options?.rollMode
         });
     }
 
@@ -113,9 +114,10 @@ export class RollUtility {
      * @param {Actor} actor The actor object from which the roll is being called. 
      * @param {String} skillId The id of the skill being rolled.
      * @param {Roll} roll The roll object that was made for the check.
+     * @param {Object} options Additional options for rolling a skill.
      * @returns {Promise<QuickRoll>} The created quick roll.
      */
-    static async rollSkill(actor, skillId, roll) {
+    static async rollSkill(actor, skillId, roll, options = {}) {
         LogUtility.log(`Quick rolling skill check from Actor '${actor.name}'.`);
 
         if (!(skillId in CONFIG.DND5E.skills)) {
@@ -128,7 +130,7 @@ export class RollUtility {
         let title = CoreUtility.localize(skill.label);
         title += SettingsUtility.getSettingValue(SETTING_NAMES.SHOW_SKILL_ABILITIES) ? ` (${CONFIG.DND5E.abilities[skill.ability]})` : "";
 
-        return await _getActorRoll(actor, title, roll, ROLL_TYPE.SKILL);
+        return await _getActorRoll(actor, title, roll, ROLL_TYPE.SKILL, options);
     }    
 
     /**
@@ -136,9 +138,10 @@ export class RollUtility {
      * @param {Actor} actor The actor object from which the roll is being called. 
      * @param {String} abilityId The id of the ability being rolled.
      * @param {Roll} roll The roll object that was made for the check.
+     * @param {Object} options Additional options for rolling an ability test.
      * @returns {Promise<QuickRoll>} The created quick roll.
      */
-    static async rollAbilityTest(actor, abilityId, roll) {
+    static async rollAbilityTest(actor, abilityId, roll, options = {}) {
         LogUtility.log(`Quick rolling ability test from Actor '${actor.name}'.`);
 
         if (!(abilityId in CONFIG.DND5E.abilities)) {
@@ -149,7 +152,7 @@ export class RollUtility {
 
         const title = `${CoreUtility.localize(CONFIG.DND5E.abilities[abilityId])} ${CoreUtility.localize(`${MODULE_SHORT}.chat.${ROLL_TYPE.ABILITY_TEST}`)}`;
 
-        return await _getActorRoll(actor, title, roll, ROLL_TYPE.ABILITY_TEST);
+        return await _getActorRoll(actor, title, roll, ROLL_TYPE.ABILITY_TEST, options);
     }
 
     /**
@@ -157,9 +160,10 @@ export class RollUtility {
      * @param {Actor} actor The actor object from which the roll is being called. 
      * @param {String} abilityId The id of the ability being rolled.
      * @param {Roll} roll The roll object that was made for the check.
+     * @param {Object} options Additional options for rolling an ability save.
      * @returns {Promise<QuickRoll>} The created quick roll.
      */
-    static async rollAbilitySave(actor, abilityId, roll) {
+    static async rollAbilitySave(actor, abilityId, roll, options = {}) {
         LogUtility.log(`Quick rolling ability save from Actor '${actor.name}'.`);
 
         if (!(abilityId in CONFIG.DND5E.abilities)) {
@@ -170,7 +174,7 @@ export class RollUtility {
 
         const title = `${CoreUtility.localize(CONFIG.DND5E.abilities[abilityId])} ${CoreUtility.localize(`${MODULE_SHORT}.chat.${ROLL_TYPE.ABILITY_SAVE}`)}`;
 
-        return await _getActorRoll(actor, title, roll, ROLL_TYPE.ABILITY_SAVE);
+        return await _getActorRoll(actor, title, roll, ROLL_TYPE.ABILITY_SAVE, options);
     }
 
     /**
@@ -192,8 +196,8 @@ export class RollUtility {
     /**
      * Processes a set of dice results to check what type of critical was rolled (for showing colour in chat card).
      * @param {Die} die A die term to process into a crit type.
-     * @param {Number} critThreshold The threshold above which a result is considered a crit.
-     * @param {Number} fumbleThreshold The threshold below which a result is considered a crit.
+     * @param {Number} options.critThreshold The threshold above which a result is considered a crit.
+     * @param {Number} options.fumbleThreshold The threshold below which a result is considered a crit.
      * @returns {CRIT_TYPE} The type of crit for the die term.
      */
     static getCritTypeForDie(die, options = {}) {
@@ -207,8 +211,8 @@ export class RollUtility {
     /**
      * Processes a set of dice results to check what type of critical was rolled (for showing colour in chat card).
      * @param {Roll} roll A die term to process into a crit type.
-     * @param {*} critThreshold The threshold above which a result is considered a crit.
-     * @param {*} fumbleThreshold The threshold below which a result is considered a crit.
+     * @param {Number} options.critThreshold The threshold above which a result is considered a crit.
+     * @param {Number} options.fumbleThreshold The threshold below which a result is considered a crit.
      * @returns {CRIT_TYPE} The type of crit for the die term.
      */
     static getCritTypeForRoll(roll, options = {}) {
@@ -347,11 +351,11 @@ export class RollUtility {
  * @param {String} title The label to show on the header of the chat card.
  * @param {String} roll The roll being quick rolled.
  * @param {String} rollType The type (as a string identifier) of the roll being quick rolled.
- * @param {Boolean} [createMessage=true] Whether the roll should immediately output to chat as a message.
+ * @param {Object} options Additional options for rolling an actor roll.
  * @returns {Promise<QuickRoll>} The created actor quick roll.
  * @private
  */
-async function _getActorRoll(actor, title, roll, rollType, createMessage = true) {
+async function _getActorRoll(actor, title, roll, rollType, options = {}) {
     if (!actor instanceof Actor) {
         LogUtility.logError(CoreUtility.localize(`${MODULE_SHORT}.messages.error.objectNotExpectedType`, { type: "Actor" }));
         return null;
@@ -381,7 +385,7 @@ async function _getActorRoll(actor, title, roll, rollType, createMessage = true)
         ]
     );
 
-    await quickroll.toMessage({ createMessage });
+    await quickroll.toMessage(options);
     return quickroll;
 }
 


### PR DESCRIPTION
Implements the possibility for roll options to be passed correctly to actor rolls even when quick rolls are enabled. Specifically, this is useful for overriding roll mode.

Fixes #133.