### PR TITLE
bugfix/apply-ammo-traits

### DIFF
--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -380,10 +380,10 @@ async function _addFieldAttack(fields, item, params) {
     if (item.hasAttack) {
         // The dnd5e default attack roll automatically consumes ammo without any option for external configuration.
         // This code will bypass this consumption since we have already consumed or not consumed via the roll config earlier.
-        let ammoConsumeBypass = false;
+        let ammoConsumeAmount = null;
         if (item.system?.consume?.type === "ammo") {
-            item.system.consume.type = "rsr5e";
-            ammoConsumeBypass = true;
+            ammoConsumeAmount = item.system?.consume?.amount ?? 0;
+            item.system.consume.amount = 0;
         }
 
         let roll = await item.rollAttack({
@@ -393,9 +393,9 @@ async function _addFieldAttack(fields, item, params) {
             disadvantage: params?.advMode < 0 ?? false
         });
 
-        // Reset ammo type to avoid later issues.
-        if (ammoConsumeBypass) {
-            item.system.consume.type = "ammo";
+        // Reset ammo to avoid later issues.
+        if (ammoConsumeAmount) {
+            item.system.consume.amount = ammoConsumeAmount;
         }
 
         // Adds a seperator for UI clarity.

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -48,8 +48,8 @@ export class RollUtility {
     /**
      * Calls the wrapped Actor roll with advantage/disadvantage determined by pressed modifier keys in the triggering event.
      * @param {Actor} caller The calling object of the wrapper.
-     * @param {function} wrapper The roll wrapper to call.
-     * @param {any} options Option data for the triggering event.
+     * @param {Function} wrapper The roll wrapper to call.
+     * @param {Object} options Option data for the triggering event.
      * @param {String} id The identifier of the roll (eg. ability name/skill name/etc).
      * @param {Boolean} bypass Is true if the quick roll should be bypassed and a default roll dialog used.
      * @returns {Promise<Roll>} The roll result of the wrapper.
@@ -69,8 +69,8 @@ export class RollUtility {
     /**
      * Calls the wrapped Item roll with advantage/disadvantage/alternate determined by pressed modifier keys in the triggering event.
      * @param {Item} caller The calling object of the wrapper.
-     * @param {function} wrapper The roll wrapper to call.
-     * @param {any} options Option data for the triggering event.
+     * @param {Function} wrapper The roll wrapper to call.
+     * @param {Object} options Option data for the triggering event.
      * @param {String} id The identifier of the roll (eg. ability name/skill name/etc).
      * @param {Boolean} bypass Is true if the quick roll should be bypassed and a default roll dialog used.
      * @returns {Promise<ChatData>} The roll result of the wrapper.


### PR DESCRIPTION
Fixes an issue where ammo attack and damage bonuses weren't correctly applied to the item rolls. 

Fixes #134.