### PR TITLE
bugfix/use-versatile-part-length

### DIFF
--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -439,7 +439,8 @@ async function _addFieldDamage(fields, item, params) {
         let damageTermGroups = [];
         let damageContextGroups = [];
         item.system.damage.parts.forEach((part, i) => {
-            const tmpRoll = new CONFIG.Dice.DamageRoll(part[0], item.getRollData()).evaluate({ async: false });
+            const damagePart = (i === 0 && (params?.versatile ?? false)) ? item.system.damage.versatile : part[0];
+            const tmpRoll = new CONFIG.Dice.DamageRoll(damagePart, item.getRollData()).evaluate({ async: false });
             const partTerms = roll.terms.splice(0, tmpRoll.terms.length);
             roll.terms.shift();
 


### PR DESCRIPTION
Fixes an issue where versatile fields would still use the part length of their base counterpart when computing part length, resulting in undesired behaviour.