### PR TITLE
bugfix/roll-crit-low-threshold

### DIFF
--- a/src/utils/render.js
+++ b/src/utils/render.js
@@ -192,7 +192,7 @@ async function _renderMultiRoll(renderData = {}) {
             tmpResults.push(d20Rolls.results[i]);
         }        
         
-        let critOptions = { critThreshold: roll.options.critical, fumbleThreshold: roll.options.fumble };
+        const critOptions = { critThreshold: roll.options.critical, fumbleThreshold: roll.options.fumble };
 
         // Die terms must have active results or the base roll total of the generated roll is 0.
         // This does not apply to dice that have been rerolled (unless they are replaced by a fixer value eg. for reliable talent).

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -289,7 +289,8 @@ export class RollUtility {
             roll.terms[roll.terms.indexOf(d20BaseTerm)] = d20Forced;
         }
 
-        const critType = RollUtility.getCritTypeForDie( roll.terms.find(d => d.faces === 20), { ignoreDiscarded: true });
+        const critOptions = { critThreshold: roll.options.critical, fumbleThreshold: roll.options.fumble, ignoreDiscarded: true };
+        const critType = RollUtility.getCritTypeForDie( roll.terms.find(d => d.faces === 20), critOptions);
 
         params.isCrit = params.isCrit || critType === CRIT_TYPE.SUCCESS;
         params.isFumble = params.isFumble || critType == CRIT_TYPE.FAILURE;


### PR DESCRIPTION
Fixes an issue where lower crit thresholds for items wouldn't correctly roll crit damage when the "Always roll multiple dice" setting was enabled.

Fixes #150.