### PR TITLE
bugfix/only-once-bonus-crit-damage

### DIFF
--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -331,7 +331,7 @@ export class RollUtility {
             critTerms.push(plus, bonusDice);
         }
 
-        if (options.criticalBonusDamage && options.criticalBonusDamage !== "") {
+        if (groupIndex === 0 && options.criticalBonusDamage && options.criticalBonusDamage !== "") {
             const bonusDamage = await new CONFIG.Dice.DamageRoll(options.criticalBonusDamage, rollData).evaluate({ async: true });
 
             critTerms.push(plus, ...bonusDamage.terms);


### PR DESCRIPTION
Fixes an issue where critical bonus damage is applied to all damage fields instead of only once.

Fixes #153.