### PR TITLE
bugfix/only-transfer-configured-effects

### DIFF
--- a/src/module/quickcard.js
+++ b/src/module/quickcard.js
@@ -217,7 +217,9 @@ export class QuickCard {
             const targetTokens = this._applyEffectsToTargeted ? game.user.targets : [];
             const targets = new Set([...selectTokens, ...targetTokens]);
 
-            window.DAE.doEffects(this.roll.item, true, targets);
+            window.DAE.doEffects(this.roll.item, true, targets, {
+                effectsToApply: this.roll.effectsToApply
+            });
         }
     }
 

--- a/src/module/quickroll.js
+++ b/src/module/quickroll.js
@@ -111,6 +111,15 @@ export class QuickRoll {
 	}
 
 	/**
+	 * Returns the list of effect IDs to apply.
+	 * @returns {Array} An array of string IDs, where each one corresponds to an active effect.
+	 */
+	get effectsToApply() {
+		const effectsFields = this.fields.filter(field => field[0] === FIELD_TYPE.EFFECTS)
+		return effectsFields.flatMap(field => field[1].apply);
+	}
+
+	/**
 	 * Creates a QuickRoll instance from data stored within chat card flags.
 	 * Used when needing to recreate chat card module data for existing chat messages.
 	 * @param {ChatMessage} message The chat card message data to retrieve a roll instance from.

--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -414,10 +414,20 @@ function _addFieldDamageButton(fields, item) {
         if (!Object.values(params.effectFlags).some(f => f === true)) {
             return;
         }
+       
+        const activeEffects = item.collections.effects.filter((effect) => !effect.disabled);
+
+        let effectsToApply = [];
+        for (let i = 0; i < activeEffects.length; i++) {
+            if (params?.effectFlags[i] ?? true) {
+                effectsToApply.push(activeEffects[i]._id);
+            }
+        }
 
         fields.push([
             FIELD_TYPE.EFFECTS,
             {
+                apply: effectsToApply
             }
         ]);
     }


### PR DESCRIPTION
Fixes an issue where all active effects would be transferred to targets, not just those configured in the quick roll.