### PR TITLE
bugfix/179-skills-ability-mod

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
 	"id": "ready-set-roll-5e",
 	"title": "Ready Set Roll for D&D5e",
 	"description": "This module overhauls rolls for the D&D 5e system in the style of BetterRolls5e.",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"compatibility": {
 		"minimum": "10.274",
 		"verified": "10.291",
@@ -59,7 +59,7 @@
 	},
 	"url": "https://github.com/MangoFVTT/fvtt-ready-set-roll-5e",
 	"manifest": "https://raw.githubusercontent.com/MangoFVTT/fvtt-ready-set-roll-5e/master/module.json",
-	"download": "https://github.com/MangoFVTT/fvtt-ready-set-roll-5e/releases/download/release-1.5.1/rsr5e-release-1.5.1.zip",
+	"download": "https://github.com/MangoFVTT/fvtt-ready-set-roll-5e/releases/download/release-1.5.2/rsr5e-release-1.5.2.zip",
 	"bugs": "https://github.com/MangoFVTT/fvtt-ready-set-roll-5e/issues",
 	"readme": "https://github.com/MangoFVTT/fvtt-ready-set-roll-5e/blob/master/README.md"
 }

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -129,7 +129,7 @@ export class RollUtility {
 
         const skill = CONFIG.DND5E.skills[skillId];
         let title = CoreUtility.localize(skill.label);
-        title += SettingsUtility.getSettingValue(SETTING_NAMES.SHOW_SKILL_ABILITIES) ? ` (${CONFIG.DND5E.abilities[skill.ability]})` : "";
+        title += SettingsUtility.getSettingValue(SETTING_NAMES.SHOW_SKILL_ABILITIES) ? ` (${CONFIG.DND5E.abilities[actor.system.skills[skillId].ability]})` : "";
 
         return await _getActorRoll(actor, title, roll, ROLL_TYPE.SKILL, options);
     }    


### PR DESCRIPTION
Changes the title of a skill check's output so that it displays the name of the attribute the actor has configured that skill to use, instead of the skill's default attribute.

Default: 
![image](https://user-images.githubusercontent.com/43473593/236774363-dcb893bb-df94-4e51-86ed-df0e538bc265.png)

Before fix:
![image](https://user-images.githubusercontent.com/43473593/236774923-7f7b30c4-d477-46ff-852d-013d1f569582.png)

After fix:
![image](https://user-images.githubusercontent.com/43473593/236774497-cc9d275e-1a0e-4beb-bdc0-d9f45f40a03f.png)


Fixes #179 