### PR TITLE
bugfix/custom-item-config

### DIFF
--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -97,7 +97,7 @@ export class HooksUtility {
 
         Hooks.on(HOOKS_DND5E.USE_ITEM, (item, config, options) => {
             if (!options?.ignore) {
-                RollUtility.rollItem(item, { ...config, ...options });
+                RollUtility.rollItem(item, foundry.utils.mergeObject(config, options, { recursive: false }));
             }
         });
     }

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -81,9 +81,11 @@ export class RollUtility {
             return await wrapper.call(caller, {}, { ignore: true });
         }
 
-        const isAltRoll = CoreUtility.eventToAltRoll(options?.event);
         const advMode = CoreUtility.eventToAdvantage(options?.event);
-        const config = ItemUtility.getRollConfigFromItem(caller, isAltRoll)
+        const isAltRoll = CoreUtility.eventToAltRoll(options?.event) || (options?.isAltRoll ?? false);
+        
+        const config = foundry.utils.mergeObject(options, ItemUtility.getRollConfigFromItem(caller, isAltRoll), { recursive: false });
+        const configureDialog = config?.configureDialog ?? (caller?.type === ITEM_TYPE.SPELL ? true : false);
 
         // Handle quantity when uses are not consumed
         // While the rest can be handled by Item._getUsageUpdates(), this one thing cannot
@@ -101,7 +103,7 @@ export class RollUtility {
         }
 
         return await wrapper.call(caller, config, {
-            configureDialog: caller?.type === ITEM_TYPE.SPELL ? true : false,
+            configureDialog,
             createMessage: false,
             advMode,
             isAltRoll,


### PR DESCRIPTION
Fixes an issue where custom configs passed to item rolls or macros would not be correctly picked up by the roller.

Fixes #163.