### PR TITLE
bugfix/dnd220-new-abilities-object-structure

### DIFF
--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -153,7 +153,7 @@ export class RollUtility {
             return null;
 		}
 
-        const title = `${CoreUtility.localize(CONFIG.DND5E.abilities[abilityId])} ${CoreUtility.localize(`${MODULE_SHORT}.chat.${ROLL_TYPE.ABILITY_TEST}`)}`;
+        const title = `${CoreUtility.localize(CONFIG.DND5E.abilities[abilityId].label || CONFIG.DND5E.abilities[abilityId])} ${CoreUtility.localize(`${MODULE_SHORT}.chat.${ROLL_TYPE.ABILITY_TEST}`)}`;
 
         return await _getActorRoll(actor, title, roll, ROLL_TYPE.ABILITY_TEST, options);
     }
@@ -175,7 +175,7 @@ export class RollUtility {
             return null;
         }
 
-        const title = `${CoreUtility.localize(CONFIG.DND5E.abilities[abilityId])} ${CoreUtility.localize(`${MODULE_SHORT}.chat.${ROLL_TYPE.ABILITY_SAVE}`)}`;
+        const title = `${CoreUtility.localize(CONFIG.DND5E.abilities[abilityId].label || CONFIG.DND5E.abilities[abilityId])} ${CoreUtility.localize(`${MODULE_SHORT}.chat.${ROLL_TYPE.ABILITY_SAVE}`)}`;
 
         return await _getActorRoll(actor, title, roll, ROLL_TYPE.ABILITY_SAVE, options);
     }


### PR DESCRIPTION
This PR aims to fix the rollAbilityTest and rollAbilitySave functions by supporting the new CONFIG.DND5E.abilities object structure in the dnd5e v2.2.0. It should be backwards compatible with previous versions. It was verified with Foundry v10.291 and dnd5e v2.2.1.

Should fix #191 