### PR TITLE
feature/situational-bonuses

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -11,6 +11,8 @@
             "enableItemQuickRoll.hint": "When clicking on an item's image (weapons, spells, features, etc.), automatically roll to chat instead of using the normal chat output. This functionality can be bypassed by holding Alt when clicking.",
             "enableAltQuickRoll.name": "Enable Alternate Roll for Items",
             "enableAltQuickRoll.hint": "When Alt-clicking on an item's image, output a different quick roll which can be configured separately, replacing the ability to bypass quick rolling for items. This setting has no effect if item quick rolling is disabled.",
+            "enableSituQuickRoll.name": "Enable Situational Bonus Rolls",
+            "enableSituQuickRoll.hint": "When right-clicking instead of left-clicking any quick roll, show a dialog that can add a situational bonus to the roll. This setting has no effect if item quick rolling is disabled.",
             "enableQuickRollDesc.name": "Enable Descriptions by Default",
             "enableQuickRollDesc.hint": "When outputting a quick roll, always show the description by default. This can still be changed per item in quick roll configuration.",
             "enableD20Icons.name": "Show D20 Rolls for Quick Rolls",
@@ -153,6 +155,15 @@
                 "title": "Apply Crit Damage?",
 		        "yes": "Yes",
 		        "no": "No"
+            },
+            "bonus": {
+                "generic": "Quick Roll Bonus",
+                "attack": "Attack Roll Bonus",
+                "ability": "Ability Check Bonus",
+                "tool": "Tool Check Bonus",
+                "damage": "Damage Roll Bonus",
+                "placeholder": "e.g. 1d4",
+                "bonus": "Bonus"
             }
         }
     }

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -9,6 +9,7 @@ import { MODULE_SHORT } from "./const.js";
  * This currently includes valid item types for roll configuration and default configuration flags.
  */
 CONFIG[MODULE_SHORT] = {
+    situRollMouseButton: 2,
     validItemTypes: [
         ITEM_TYPE.WEAPON,
         ITEM_TYPE.SPELL,

--- a/src/module/templates.js
+++ b/src/module/templates.js
@@ -16,5 +16,6 @@ export const TEMPLATE = {
     BLANK: "rsr-blank.html",
     OVERLAY_DAMAGE: "rsr-overlay-damage.html",
     OVERLAY_MULTIROLL: "rsr-overlay-multiroll.html",
-    OVERLAY_HEADER: "rsr-overlay-header.html"
+    OVERLAY_HEADER: "rsr-overlay-header.html",
+    DIALOG_BONUS: "rsr-dialog-bonus.html"
 }

--- a/src/utils/dialog.js
+++ b/src/utils/dialog.js
@@ -1,0 +1,38 @@
+import { LogUtility } from "./log.js";
+import { RenderUtility } from "./render.js";
+
+/**
+ * Utility class for handing configuration dialogs.
+ */
+export class DialogUtility {
+    static async getBonusFromDialog(groups = []) {
+        LogUtility.log(`Retrieving situational bonuses from dialog.`);
+
+        if (groups.length === 0) {
+            return;
+        }
+
+        const html = await RenderUtility.renderDialogBonus({ groups });
+        
+        return new Promise((resolve, reject) => {
+            new Dialog({
+                title: `Configure Situational Bonuses`,
+                content: html,
+                buttons: {
+                    yes: {
+                        icon: '<i class="fas fa-check"></i>',
+                        label: 'Confirm',
+                        callback: html => resolve(Array.from(html.find('[name="rsr-bonus"]')).map(e => { 
+                            return { id: e.id, value: e.value }
+                        }))
+                    },
+                    no: {
+                        icon: '<i class="fas fa-times"></i>',
+                        label: 'Cancel'
+                    }
+                },
+                default: "yes"
+            }, {}).render(true);
+        });
+    }
+}

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -21,7 +21,10 @@ export const HOOKS_DND5E = {
     USE_ITEM: "dnd5e.useItem",
     PRE_DISPLAY_CARD: "dnd5e.preDisplayCard",
     DISPLAY_CARD: "dnd5e.displayCard",
-    RENDER_ITEM_SHEET: "renderItemSheet5e"
+    PRE_ROLL_SKILL: "dnd5e.preRollSkill",
+    PRE_ROLL_TOOL: "dnd5e.preRollToolCheck",
+    RENDER_ITEM_SHEET: "renderItemSheet5e",
+    RENDER_ACTOR_SHEET: "renderActorSheet5e"
 }
 
 export const HOOKS_MODULE = {
@@ -117,7 +120,11 @@ export class HooksUtility {
     static registerSheetHooks() {
         Hooks.on(HOOKS_DND5E.RENDER_ITEM_SHEET, (app, html, data) => {
             SheetUtility.setAutoHeightOnSheet(app);
-            SheetUtility.addModuleContentToSheet(app, html);
+            SheetUtility.addModuleContentToItemSheet(app, html);
+        });
+
+        Hooks.on(HOOKS_DND5E.RENDER_ACTOR_SHEET, (app, html, data) => {
+            SheetUtility.addModuleContentToActorSheet(app, html);
         });
     }
 }

--- a/src/utils/render.js
+++ b/src/utils/render.js
@@ -100,7 +100,15 @@ export class RenderUtility {
      */
     static renderOverlayHeader() {
         return _renderModuleTemplate(TEMPLATE.OVERLAY_HEADER, {});
-    }  
+    }
+
+    /**
+     * Renders a user interface for resolving a situational bonus striung.
+     * @returns {Promise<String>} The rendered html data for the item sheet.
+     */
+    static renderDialogBonus(props) {
+        return _renderModuleTemplate(TEMPLATE.DIALOG_BONUS, props);
+    }
 }
 
 function _renderBlank(renderData = {}) {

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -13,6 +13,7 @@ export const SETTING_NAMES = {
     QUICK_DEATH_ENABLED: "enableDeathQuickRoll",
     QUICK_ITEM_ENABLED: "enableItemQuickRoll",
     ALT_ROLL_ENABLED: "enableAltQuickRoll",
+    SITU_ROLL_ENABLED: "enableSituQuickRoll",
     QUICK_ROLL_DESC_ENABLED: "enableQuickRollDesc",
     D20_ICONS_ENABLED: "enableD20Icons",
     DICE_SOUNDS_ENABLED: "enableDiceSounds",
@@ -80,6 +81,7 @@ export class SettingsUtility {
         // ADDITIONAL ROLL SETTINGS
         const extraRollOptions = [
             { name: SETTING_NAMES.ALT_ROLL_ENABLED, default: false, scope: "world" },
+            { name: SETTING_NAMES.SITU_ROLL_ENABLED, default: false, scope: "world" },
             { name: SETTING_NAMES.QUICK_ROLL_DESC_ENABLED, default: false, scope: "world" },
             { name: SETTING_NAMES.ALWAYS_ROLL_MULTIROLL, default: false, scope: "client"  },
             { name: SETTING_NAMES.ALWAYS_MANUAL_DAMAGE, default: false, scope: "client"  }

--- a/templates/rsr-dialog-bonus.html
+++ b/templates/rsr-dialog-bonus.html
@@ -1,0 +1,8 @@
+<form>
+    {{#each groups}}
+    <div class="form-group">
+        <label>{{this.label}}</label>
+        <input type="text" id="{{this.id}}" name="rsr-bonus" value placeholder="{{localize 'rsr5e.chat.bonus.placeholder'}}">
+    </div>
+    {{/each}}
+</form>


### PR DESCRIPTION
Implements a system for adding situational bonuses to quick rolls by right-clicking the roll instead of the usual left click. The normal key modifiers can still apply.

Fixes #94.