### PR TITLE
feature/expanded-apply-options

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -91,7 +91,9 @@
             "apply": {
                 "0": "Apply to Selected Tokens",
                 "1": "Apply to Targeted Tokens",
-                "2": "Apply to Both"
+                "2": "Apply to Both",
+                "3": "Prioritise Selected Tokens",
+                "4": "Prioritise Targeted Tokens"
             },
             "hideSaveDC": {
                 "0": "Never",

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -129,7 +129,9 @@ export class SettingsUtility {
             choices: {
                 0: CoreUtility.localize(`${MODULE_SHORT}.choices.apply.0`),
                 1: CoreUtility.localize(`${MODULE_SHORT}.choices.apply.1`),
-                2: CoreUtility.localize(`${MODULE_SHORT}.choices.apply.2`)
+                2: CoreUtility.localize(`${MODULE_SHORT}.choices.apply.2`),
+                3: CoreUtility.localize(`${MODULE_SHORT}.choices.apply.3`),
+                4: CoreUtility.localize(`${MODULE_SHORT}.choices.apply.4`)
             }
         });
         
@@ -156,7 +158,9 @@ export class SettingsUtility {
                 choices: {
                     0: CoreUtility.localize(`${MODULE_SHORT}.choices.apply.0`),
                     1: CoreUtility.localize(`${MODULE_SHORT}.choices.apply.1`),
-                    2: CoreUtility.localize(`${MODULE_SHORT}.choices.apply.2`)
+                    2: CoreUtility.localize(`${MODULE_SHORT}.choices.apply.2`),
+                    3: CoreUtility.localize(`${MODULE_SHORT}.choices.apply.3`),
+                    4: CoreUtility.localize(`${MODULE_SHORT}.choices.apply.4`)
                 }
             });
         }


### PR DESCRIPTION
Adds expanded options for applying damage or effects, specifically to prioritise either selected or targeted tokens even when you have both. 

Fixes #164.