### PR TITLE
bugfix/refresh-flags-on-ammunition

### DIFF
--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -308,7 +308,9 @@ export class ItemUtility {
  */
 function _getConsumeTargetFromItem(item) {
     if (item.system.consume.type === "ammo") {
-        return item.actor.items.get(item.system.consume.target);
+        const target = item.actor.items.get(item.system.consume.target);
+        ItemUtility.ensureFlagsOnitem(target);
+        return target;
     }
 
     return undefined;


### PR DESCRIPTION
Fixes an issue where items using old ammunition from before 2.0.0 would fail to roll because that ammunition did not have the correct flags on it.

Fixes #209.