### PR TITLE
feature/expanded-manual-damage-options

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -33,8 +33,8 @@
             "alwaysApplyCrit.hint": "When using damage overlay buttons, always apply the rolled critical damage (if any). If turned off, using an overlay button for critical damage will display a prompt allowing the user to choose.",
             "alwaysRollMulti.name": "Always Roll Multiple Dice",
             "alwaysRollMulti.hint": "When outputting a quick roll, always roll two dice (or three for Elven Accuracy) even when advantage/disadvantage is not applied.",
-            "alwaysManualDamage.name": "Always Roll Damage Manually",
-            "alwaysManualDamage.hint": "When outputting a quick roll, do not quick roll damage. Instead, show a damage button to manually roll if there is damage available.",
+            "manualDamageMode.name": "Roll Damage Manually",
+            "manualDamageMode.hint": "When outputting a quick roll, do not quick roll damage. Instead, show a damage button to manually roll if there is damage available.",
             "showSkillAbilities.name": "Show Ability Names for Skills",
             "showSkillAbilities.hint": "When outputting a skill quick roll, display the name of the ability used next to the skill name.",
             "rollModifierMode.name": "Roll Modifier Keys",
@@ -87,6 +87,11 @@
                 "1": "Above",
                 "2": "Below & Inside",
                 "3": "Below & Outside"
+            },
+            "manual": {
+                "0": "Never",
+                "1": "Attack Rolls Only",
+                "2": "Always"
             },
             "apply": {
                 "0": "Apply to Selected Tokens",

--- a/src/module/quickcard.js
+++ b/src/module/quickcard.js
@@ -123,7 +123,7 @@ export class QuickCard {
      * @param {JQuery} html The object to add button handlers to.
      */
     _setupActionButtons(html) {        
-        if (SettingsUtility.getSettingValue(SETTING_NAMES.ALWAYS_MANUAL_DAMAGE)) {
+        if (SettingsUtility.getSettingValue(SETTING_NAMES.MANUAL_DAMAGE_MODE) > 0) {
             html.find(".rsr-damage-buttons button").click(async evt => {
                 await this._processDamageButtonEvent(evt);
             });

--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -37,7 +37,8 @@ export class ItemUtility {
         ItemUtility.ensureFlagsOnitem(item);
         ItemUtility.ensureItemParams(item, params);
         
-        const manualDamage = SettingsUtility.getSettingValue(SETTING_NAMES.ALWAYS_MANUAL_DAMAGE);
+        const manualDamageMode = SettingsUtility.getSettingValue(SETTING_NAMES.MANUAL_DAMAGE_MODE);
+        const manualDamage = manualDamageMode === 2 || (manualDamageMode === 1 && item.hasAttack);
         const applyEffects = CoreUtility.hasDAE() && SettingsUtility.getSettingValue(SETTING_NAMES.APPLY_EFFECTS_ENABLED);
         const chatData = await item.getChatData();
         let fields = [];

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -136,7 +136,7 @@ export class RollUtility {
                 groups.push({ label: CoreUtility.localize(`${MODULE_SHORT}.chat.bonus.tool`), id: ROLL_TYPE.TOOL });
             }
 
-            if (caller.hasDamage && !SettingsUtility.getSettingValue(SETTING_NAMES.ALWAYS_MANUAL_DAMAGE)) {
+            if (caller.hasDamage && SettingsUtility.getSettingValue(SETTING_NAMES.MANUAL_DAMAGE_MODE) === 0) {
                 groups.push({ label: CoreUtility.localize(`${MODULE_SHORT}.chat.bonus.damage`), id: ROLL_TYPE.DAMAGE });
             }
 

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -33,7 +33,7 @@ export const SETTING_NAMES = {
     HIDE_SAVE_DC: "hideSaveDC",
     SHOW_SKILL_ABILITIES: "showSkillAbilities",
     ALWAYS_ROLL_MULTIROLL: "alwaysRollMulti",
-    ALWAYS_MANUAL_DAMAGE: "alwaysManualDamage"
+    MANUAL_DAMAGE_MODE: "manualDamageMode"
 }
 
 /**
@@ -84,8 +84,7 @@ export class SettingsUtility {
             { name: SETTING_NAMES.ALT_ROLL_ENABLED, default: false, scope: "world" },
             { name: SETTING_NAMES.SITU_ROLL_ENABLED, default: false, scope: "world" },
             { name: SETTING_NAMES.QUICK_ROLL_DESC_ENABLED, default: false, scope: "world" },
-            { name: SETTING_NAMES.ALWAYS_ROLL_MULTIROLL, default: false, scope: "client"  },
-            { name: SETTING_NAMES.ALWAYS_MANUAL_DAMAGE, default: false, scope: "client"  }
+            { name: SETTING_NAMES.ALWAYS_ROLL_MULTIROLL, default: false, scope: "client"  }
         ];
 
         extraRollOptions.forEach(option => {
@@ -97,6 +96,20 @@ export class SettingsUtility {
                 type: Boolean,
                 default: option.default,
             });
+        });
+
+        game.settings.register(MODULE_NAME, SETTING_NAMES.MANUAL_DAMAGE_MODE, {
+            name: CoreUtility.localize(`${MODULE_SHORT}.settings.${SETTING_NAMES.MANUAL_DAMAGE_MODE}.name`),
+            hint: CoreUtility.localize(`${MODULE_SHORT}.settings.${SETTING_NAMES.MANUAL_DAMAGE_MODE}.hint`),
+            scope: "client",
+            config: true,
+            type: Number,
+            default: 0,
+            choices: {
+                0: CoreUtility.localize(`${MODULE_SHORT}.choices.manual.0`),
+                1: CoreUtility.localize(`${MODULE_SHORT}.choices.manual.1`),
+                2: CoreUtility.localize(`${MODULE_SHORT}.choices.manual.2`)
+            }
         });
 
         // CHAT CARD OPTIONS


### PR DESCRIPTION
Adds options to the manual damage setting to allow manual damage rolling only on attack rolls if desired.

Fixes #137.