### PR TITLE
bugfix/heavy-armor-master-fixes

### DIFF
--- a/src/module/quickcard.js
+++ b/src/module/quickcard.js
@@ -339,7 +339,7 @@ export class QuickCard {
         await Promise.all(Array.from(targets).map(t => {
             const target = t.actor;
 
-            if (SettingsUtility.getSettingValue(SETTING_NAMES.APPLY_DAMAGE_MODS)) {
+            if (SettingsUtility.getSettingValue(SETTING_NAMES.APPLY_DAMAGE_MODS) && !isTempHP && modifier > 0) {
                 damage = CoreUtility.resolveDamageModifiers(target, damage, type, this.roll.item);
             }
             

--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -118,8 +118,10 @@ export class CoreUtility {
         // FEAT: HEAVY ARMOR MASTER
         const heavyArmorMaster = target.items.some(i => i.type === ITEM_TYPE.FEATURE && i.name.toLowerCase().includes('heavy armor master'));
 
-        if (heavyArmorMaster && !item.system.properties.mgc && CONFIG.DND5E.physicalDamageTypes[type]) {
-            result -= 3;
+        if (heavyArmorMaster) {
+            if (item.type === ITEM_TYPE.WEAPON && !item.system?.properties?.mgc && CONFIG.DND5E.physicalDamageTypes[type]) {
+                result -= 3;
+            }
         }
 
         return result;


### PR DESCRIPTION
Fixes an issue where healing and temporary HP would attempt to calculate resistances and immunities despite these never applying to heal "damage". Fixes an issue where the check for Heavy Armor Master would break for items that aren't weapons.

Fixes #230.