### PR TITLE
bugfix/reliable-talent-issues

### DIFF
--- a/src/utils/render.js
+++ b/src/utils/render.js
@@ -204,7 +204,11 @@ async function _renderMultiRoll(renderData = {}) {
         let tmpResults = [];
         tmpResults.push(d20Rolls.results[i]);
 
-        while (d20Rolls.results[i].rerolled) {
+        while (d20Rolls?.results[i]?.rerolled && !d20Rolls?.results[i]?.count) {
+            if ((i + 1) >= d20Rolls.results.length) {
+                break;
+            }
+
             i++;
             tmpResults.push(d20Rolls.results[i]);
         }


### PR DESCRIPTION
Fixes an issue where rerolled dice with a fixed value (e.g. for reliable talent) would get incorrectly processed as dice rerolled manually by a user.

Fixes #243 and #250.