### PR TITLE
Bugfix/missing tool ids

### DIFF
--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -80,6 +80,18 @@ export class HooksUtility {
                 { recursive: false }
             );
 
+            const combinedToolIds = foundry.utils.mergeObject(
+                foundry.utils.duplicate(CONFIG.DND5E.toolIds),
+                foundry.utils.duplicate(CONFIG.DND5E.vehicleTypes),
+                { recursive: false }
+            );
+
+            CONFIG[MODULE_SHORT].combinedToolTypes = foundry.utils.mergeObject(
+                combinedToolIds,
+                foundry.utils.duplicate(CONFIG.DND5E.toolProficiencies),
+                { recursive: false }
+            );
+
             if (SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_ITEM_ENABLED)) { 
                 HooksUtility.registerSheetHooks();
                 HooksUtility.registerItemHooks();

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -205,13 +205,9 @@ export class RollUtility {
             return null;
 		}
 
-        let tool;
-        if (toolId in CONFIG.DND5E.toolIds) {
-            tool = CoreUtility.getBaseItemIndex(CONFIG.DND5E.toolIds[toolId]);
-            options.img = tool.img;
-        } else {
-            tool = { name: CONFIG[MODULE_SHORT].combinedToolTypes[toolId] };
-        }
+        const tool = toolId in CONFIG.DND5E.toolIds 
+            ? CoreUtility.getBaseItemIndex(CONFIG.DND5E.toolIds[toolId]) 
+            : { name: CONFIG[MODULE_SHORT].combinedToolTypes[toolId] };
 
         const abilityId = options.ability || (actor.system.tools[toolId]?.ability ?? "int");
 
@@ -222,6 +218,7 @@ export class RollUtility {
 		}
 
         const ability = CONFIG.DND5E.abilities[abilityId];
+        options.img = tool.img;
 
         const title = `${tool.name}${SettingsUtility.getSettingValue(SETTING_NAMES.SHOW_SKILL_ABILITIES) ? ` (${ability.label})` : ""}`;
 

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -199,13 +199,20 @@ export class RollUtility {
     static async rollTool(actor, toolId, roll, options = {}) {        
         LogUtility.log(`Quick rolling tool check from Actor '${actor.name}'.`);
 
-        if (!(toolId in CONFIG.DND5E.toolIds)) {
+        if (!(toolId in CONFIG[MODULE_SHORT].combinedToolTypes)) {
             LogUtility.logError(CoreUtility.localize(`${MODULE_SHORT}.messages.error.labelNotInDictionary`,
-                { type: "Tool", label: toolId, dictionary: "CONFIG.DND5E.toolIds" }));
+                { type: "Tool", label: toolId, dictionary: "CONFIG.DND5E.toolIds, CONFIG.DND5E.toolProficiencies, or CONFIG.DND5E.vehicleTypes" }));
             return null;
 		}
 
-        const tool = CoreUtility.getBaseItemIndex(CONFIG.DND5E.toolIds[toolId]);
+        let tool;
+        if (toolId in CONFIG.DND5E.toolIds) {
+            tool = CoreUtility.getBaseItemIndex(CONFIG.DND5E.toolIds[toolId]);
+            options.img = tool.img;
+        } else {
+            tool = { name: CONFIG[MODULE_SHORT].combinedToolTypes[toolId] };
+        }
+
         const abilityId = options.ability || (actor.system.tools[toolId]?.ability ?? "int");
 
         if (!(abilityId in CONFIG.DND5E.abilities)) {
@@ -217,7 +224,6 @@ export class RollUtility {
         const ability = CONFIG.DND5E.abilities[abilityId];
 
         const title = `${tool.name}${SettingsUtility.getSettingValue(SETTING_NAMES.SHOW_SKILL_ABILITIES) ? ` (${ability.label})` : ""}`;
-        options.img = tool.img;
 
         return _getActorRoll(actor, title, roll, ROLL_TYPE.TOOL, options);
     }

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -218,9 +218,9 @@ export class RollUtility {
 		}
 
         const ability = CONFIG.DND5E.abilities[abilityId];
-        options.img = tool.img;
 
         const title = `${tool.name}${SettingsUtility.getSettingValue(SETTING_NAMES.SHOW_SKILL_ABILITIES) ? ` (${ability.label})` : ""}`;
+        options.img = tool.img;
 
         return _getActorRoll(actor, title, roll, ROLL_TYPE.TOOL, options);
     }


### PR DESCRIPTION
Fixes an issue where vehicles and tool categories would not be correctly picked up as viable tools for quick rolling.

Fixes #239.