### PR TITLE
bugfix/incorrect-crit-maximizing

### DIFF
--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -562,10 +562,11 @@ async function _addFieldDamage(fields, item, params) {
         }
 
         for (const [i, group] of damageTermGroups.entries()) {
-            const baseRoll = Roll.fromTerms(group.terms);
-            
+            let baseRoll = Roll.fromTerms(group.terms);            
             let critRoll = null;
+
             if (params?.isCrit) {
+                baseRoll = await RollUtility.getCritBaseRoll(baseRoll, i, item.getRollData(), roll.options);
                 critRoll = await RollUtility.getCritRoll(baseRoll, i, item.getRollData(), roll.options);
             }
 

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -448,6 +448,33 @@ export class RollUtility {
     }
 
     /**
+     * Generates the base roll for a critical roll from an original base roll.
+     * @param {Roll} baseRoll The base roll to convert for a crit roll.
+     * @param {Number} groupIndex The index of the damage group. Some crit options only apply to the first damage group.
+     * @param {Object} rollData Roll data for the item to calculate modifiers if needed.
+     * @param {Object} options Additional options for rolling critical damage.
+     * @returns {Promise<Roll>} The critical roll for the given base.
+     */
+    static async getCritBaseRoll(baseRoll, groupIndex, rollData, options = {}) {
+        const origTerms = foundry.utils.duplicate(baseRoll.terms);
+
+        const baseTerms = [];
+        origTerms.forEach(term => {
+            let baseTerm = RollTerm.fromData(term);
+
+            baseTerm._evaluated = false;
+            baseTerm.results = [];
+
+            baseTerms.push(baseTerm);
+        });
+
+        return await Roll.fromTerms(baseTerms).evaluate({ 
+            maximize: options.powerfulCritical,
+            async: true
+        });
+    }    
+
+    /**
      * Generates a critical roll from a given base roll.
      * @param {Roll} baseRoll The base roll to roll a crit for.
      * @param {Number} groupIndex The index of the damage group. Some crit options only apply to the first damage group.
@@ -472,7 +499,7 @@ export class RollUtility {
 
         const firstDie = critTerms.find(t => t instanceof Die);
 
-        if (options.criticalBonusDice && options.criticalBonusDice > 0 && groupIndex === 0 && firstDie) {
+        if (groupIndex === 0 && options.criticalBonusDice && options.criticalBonusDice > 0 && firstDie) {
             const bonusDice = await new Die({ number: options.criticalBonusDice, faces: firstDie.faces }).evaluate({ async: true });
 
             critTerms.push(plus, bonusDice);
@@ -490,7 +517,6 @@ export class RollUtility {
         }
 
         return await Roll.fromTerms(Roll.simplifyTerms(critTerms)).reroll({
-            maximize: options.powerfulCritical,
             async: true
         });
     }


### PR DESCRIPTION
Fixes an issue where selecting the powerful criticals option would incorrectly maximize the critical dice instead of the base dice.

Fixes #262.