### PR TITLE
bugfix/spell-upcasting

### DIFF
--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -301,7 +301,14 @@ export class RollUtility {
         LogUtility.log(`Quick rolling Item '${item.name}'.`);
 
         params = CoreUtility.ensureQuickRollParams(params);
-        params.slotLevel = params.slotLevel ?? item.system.level;
+
+        if (params.slotLevel) {
+            params.slotLevel = Number.isInteger(params.slotLevel) ? params.slotLevel
+                : params.slotLevel === "pact" ? item.actor.spells.pact.level : parseInt(params.slotLevel.replace("spell", ""));
+        } else {
+            params.slotLevel = item.system.level;
+        }
+        
         params.createMessage = createMessage;
         item.system.level = params.spellLevel ?? item.system.level;
 


### PR DESCRIPTION
Fixes an issue with upcasted spells due to a change in item config in dnd5e 2.4.0.

Fixes #271.