### PR TITLE
[Feature] Integration with AutomatedAnimations - Animations on Damage Applying

### DIFF
--- a/src/module/quickcard.js
+++ b/src/module/quickcard.js
@@ -336,6 +336,15 @@ export class QuickCard {
 
         const targets = new Set([...selectTokens, ...targetTokens]);
 
+        // Hook for AA integration
+        if (game.modules.get("autoanimations")?.active) {
+            const button = event.currentTarget;
+            const id = $(button).parents(".dice-roll.rsr-dual").attr('data-id');
+            if(await this.roll.upgradeToDamageRoll(id)) {
+                Hooks.call("autoAnimationOnDmg", Array.from(targets), this.roll.item, this.roll);
+            }
+        }
+
         await Promise.all(Array.from(targets).map(t => {
             const target = t.actor;
 


### PR DESCRIPTION
**Problem**: My players are fairly dumb. Out of 6, only 1 actually remembers to target stuff when attacking. We use both [RSR](https://github.com/MangoFVTT/fvtt-ready-set-roll-5e) and [AA](https://github.com/otigon/automated-jb2a-animations), so only 1 of the players actually triggers animations when attacking. For myself, I'm also fairly dumb when DMing, so I never have my NPCs targeting the characters, and we never see Bite animations from my Dragons, or Morningstar animations from my Bugbears.

**Solution**: Now, RSR gives us that neat little Quickcard where I apply damage to selected tokens by clicking the damage of an attack. So in fact, there should be no need to target tokens; when we apply damage to one, we have all the ingredients we need to trigger an attack animation: source (author of quickcard), item/feature (quickcard), and target (selected token)). So I would propose a custom RSR hook which is later caught by [AA](https://github.com/otigon/automated-jb2a-animations/pull/693). 

It has some limitations, since a multi-damage attack triggers multiple animations (a poisoned weapon will trigger weapon+poison damage); perhaps some global variable with the latest triggered `this.roll.item` and `target` could be used to prevent multiple Hook calls. Could be done from AA side though.

**Alternatives**: AFAIK there is no module to support this. There is no way to trigger animations on damage macros that can be easily hooked in here. Maybe I'm wrong.

**Demo**:

https://github.com/MangoFVTT/fvtt-ready-set-roll-5e/assets/9117323/933b91ac-7f91-46fc-9ae2-5fc7cd6509cc

