### PR TITLE
bugfix/retroactive-crit-max

### DIFF
--- a/src/module/quickroll.js
+++ b/src/module/quickroll.js
@@ -309,6 +309,7 @@ export class QuickRoll {
 		}
 		
 		const damageFields = this.fields.filter(f => f[0] === FIELD_TYPE.DAMAGE);
+		targetField[1].baseRoll = await RollUtility.getCritBaseRoll(targetField[1].baseRoll, damageFields.indexOf(targetField), this.item?.getRollData(), options);
 		targetField[1].critRoll = await RollUtility.getCritRoll(targetField[1].baseRoll, damageFields.indexOf(targetField), this.item?.getRollData(), options);
 
 		await CoreUtility.tryRollDice3D(targetField[1].critRoll);

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -477,7 +477,7 @@ export class RollUtility {
         });
 
         return await Roll.fromTerms(baseTerms).evaluate({ 
-            // maximize: options.powerfulCritical,
+            maximize: options.powerfulCritical,
             async: true
         });
     }    
@@ -525,7 +525,6 @@ export class RollUtility {
         }
 
         return await Roll.fromTerms(Roll.simplifyTerms(critTerms)).reroll({
-            maximize: options.powerfulCritical,
             async: true
         });
     }

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -476,7 +476,7 @@ export class RollUtility {
         });
 
         return await Roll.fromTerms(baseTerms).evaluate({ 
-            maximize: options.powerfulCritical,
+            // maximize: options.powerfulCritical,
             async: true
         });
     }    

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -524,6 +524,7 @@ export class RollUtility {
         }
 
         return await Roll.fromTerms(Roll.simplifyTerms(critTerms)).reroll({
+            maximize: options.powerfulCritical,
             async: true
         });
     }


### PR DESCRIPTION
Fixes an issue where the base roll of a crit would not be correctly updated when retroactively upgrading the damage field into a crit.

Fixes #291.