### PR TITLE
hotfix/template-path-error

### DIFF
--- a/src/utils/render.js
+++ b/src/utils/render.js
@@ -94,5 +94,5 @@ async function _renderDamageRoll(data = {}) {
  */
 function _renderModuleTemplate(template, data) {
     //return renderTemplate(`modules/${MODULE_NAME}/templates/${template}`, data);
-    return renderTemplate(`modules/ready-set-roll-5e-v3/templates/${template}`, data);
+    return renderTemplate(`modules/ready-set-roll-5e/templates/${template}`, data);
 }


### PR DESCRIPTION
Fix an issue with incorrect template paths lingering from the rewrite.

Fixes #312.