### PR TITLE
bugfix/missing-damage-properties

### DIFF
--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -503,9 +503,11 @@ async function _processApplyButtonEvent(message, event) {
     const type = dice.find('.label').text().toLowerCase();
     const multiplier = button.dataset.multiplier;
 
+    const properties = new Set(message.rolls.find(r => r instanceof CONFIG.Dice.DamageRoll)?.options?.properties ?? []);
+
     await Promise.all(Array.from(targets).map(t => {
         const target = t.actor;        
-        return isTempHP ? target.applyTempHP(damage) : target.applyDamage([{ value: damage, type: type}], { multiplier });
+        return isTempHP ? target.applyTempHP(damage) : target.applyDamage([{ value: damage, type: type, properties: properties }], { multiplier });
     }));
 
     setTimeout(() => {


### PR DESCRIPTION
Fixes an issue where item properties were not correctly passed to apply damage buttons, causing incorrect damage to be applied to tokens when taking into consideration resistances/immunities/vulnerabilities.

Fixes #319.