### PR TITLE
feature/always-on-damage-buttons

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -27,6 +27,8 @@
             "enableOverlayButtons.hint": "When outputting a quick roll, enable overlay buttons on the chat message that offer additional functionality for the roll.",
             "enableDamageButtons.name": "Enable Damage Apply Buttons",
             "enableDamageButtons.hint": "When outputting a quick roll with damage, enable buttons on the chat message that allow for that damage to be applied to tokens.",
+            "alwaysShowButtons.name": "Always Show Damage Apply Buttons",
+            "alwaysShowButtons.hint": "When outputting a quick roll chat card, always show the damage apply buttons, instead of only on hover.",
             "applyDamageTo.name": "Apply Damage Options",
             "applyDamageTo.hint": "Determines which tokens damage is applied to when applying damage via the chat overlay buttons."
         },

--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -82,13 +82,13 @@ export class ChatUtility {
             // Setup hover buttons when the message is actually hovered(for optimisation).
             let hoverSetupComplete = false;
             content.hover(async () => {
-                if (!hoverSetupComplete) {                    
+                if (!hoverSetupComplete) {
                     LogUtility.log("Injecting overlay hover buttons")
                     hoverSetupComplete = true;
                     await _injectOverlayButtons(message, content);
                     _onOverlayHover(message, content);
                 }
-            })
+            });
         }
     }
 
@@ -367,11 +367,13 @@ async function _injectApplyDamageButtons(message, html) {
     const tooltip = html.find('.rsr-damage .dice-tooltip .tooltip-part')
     tooltip.append($(render));
 
-    // Enable Hover Events (to show/hide the elements).
-    tooltip.each((i, el) => {        
-        $(el).find(".rsr-damage-buttons").attr("style", "display: none;height: 0px");
-        $(el).hover(_onTooltipHover.bind(this, message, $(el)), _onTooltipHoverEnd.bind(this, $(el)));
-    })
+    if (!SettingsUtility.getSettingValue(SETTING_NAMES.ALWAYS_SHOW_BUTTONS)) {
+        // Enable Hover Events (to show/hide the elements).
+        tooltip.each((i, el) => {        
+            $(el).find(".rsr-damage-buttons").attr("style", "display: none;height: 0px");
+            $(el).hover(_onTooltipHover.bind(this, message, $(el)), _onTooltipHoverEnd.bind(this, $(el)));
+        })
+    }
 }
 
 async function _injectToolCheckRoll(message, html) {
@@ -403,7 +405,7 @@ async function _injectToolCheckRoll(message, html) {
  */
 async function _injectOverlayButtons(message, html) {
     await _injectOverlayRetroButtons(message, html);
-    await _injectOverlayHeaderButtons(message, html);
+    await _injectOverlayHeaderButtons(message, html);    
     
     // Enable Hover Events (to show/hide the elements).
     _onOverlayHoverEnd(html);

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -19,8 +19,8 @@ export const SETTING_NAMES = {
     MANUAL_DAMAGE_MODE: "manualDamageMode",
     OVERLAY_BUTTONS_ENABLED: "enableOverlayButtons",
     DAMAGE_BUTTONS_ENABLED: "enableDamageButtons",
+    ALWAYS_SHOW_BUTTONS: "alwaysShowButtons",
     DICE_REROLL_ENABLED: "enableDiceReroll",
-    APPLY_DAMAGE_MODS: "applyDamageMods",
     APPLY_DAMAGE_TO: "applyDamageTo",
     ALWAYS_ROLL_MULTIROLL: "alwaysRollMulti",
 }
@@ -106,6 +106,7 @@ export class SettingsUtility {
             { name: SETTING_NAMES.DICE_REROLL_ENABLED, default: true },
             { name: SETTING_NAMES.OVERLAY_BUTTONS_ENABLED, default: true },
             { name: SETTING_NAMES.DAMAGE_BUTTONS_ENABLED, default: true },
+            { name: SETTING_NAMES.ALWAYS_SHOW_BUTTONS, default: false },
         ]        
 
         chatCardOptions.forEach(option => {


### PR DESCRIPTION
Adds functionality for the damage apply buttons to always be visible, instead of only on hover.

Partially implements #323.