### PR TITLE
bugfix/jump-to-bottom

### DIFF
--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -265,6 +265,8 @@ async function _injectContent(message, html) {
 
     //_setupRerollDice(html);
     _setupCardListeners(message, html);
+
+    ui.chat.scrollBottom();
 }
 
 async function _injectAttackRoll(message, html) {


### PR DESCRIPTION
Fixes an issue where chat wouldn't jump to bottom when creating RSR chat cards.

Fixes #327.