### PR TITLE
regression/hit-or-miss-indicators

### DIFF
--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -288,7 +288,8 @@ async function _injectAttackRoll(message, html) {
     $(sectionHTML).append(rollHTML);
     sectionHTML.insertBefore(html);
 
-    message._enrichAttackTargets(html.parent()[0]);
+    message.rolls.push(roll);
+    message._enrichAttackTargets(html.closest('.chat-message')[0]);
 }
 
 async function _injectDamageRoll(message, html) {


### PR DESCRIPTION
Fix a regression issue where hit or miss indicators were once again not correctly displaying.

Fixes #338.