### PR TITLE
bugfix/hit-or-miss-retro-rolls

### DIFF
--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -267,7 +267,7 @@ async function _injectAttackRoll(message, html) {
     const ChatMessage5e = CONFIG.ChatMessage.documentClass;
 
     const roll = CONFIG.Dice.D20Roll.fromData(message.flags[MODULE_SHORT].rolls[ROLL_TYPE.ATTACK]);
-    roll.resetFormula();
+    RollUtility.resetRollGetters(roll);
 
     const render = await RenderUtility.render(TEMPLATE.MULTIROLL, { roll, key: ROLL_TYPE.ATTACK })
 
@@ -288,8 +288,11 @@ async function _injectAttackRoll(message, html) {
     $(sectionHTML).append(rollHTML);
     sectionHTML.insertBefore(html);
 
-    message.rolls.push(roll);
-    message._enrichAttackTargets(html.closest('.chat-message')[0]);
+    // Remove and re-add enrichers for hit/miss indication
+    message.rolls[0] = roll;
+    const card = html.closest('.chat-message');
+    card.find('.evaluation').remove();
+    message._enrichAttackTargets(card[0]);
 }
 
 async function _injectDamageRoll(message, html) {

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -111,7 +111,8 @@ export class RollUtility {
             });
 
             roll.terms[roll.terms.indexOf(d20BaseTerm)] = d20Forced;
-            roll.resetFormula();
+
+            RollUtility.resetRollGetters(roll);
         }
 
         return roll;
@@ -143,9 +144,14 @@ export class RollUtility {
         upgradedRoll.options.advantageMode = targetState === ROLL_STATE.ADV 
             ? CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE 
             : CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE;
-        upgradedRoll.resetFormula();
 
+        RollUtility.resetRollGetters(upgradedRoll);
         return upgradedRoll;
+    }
+
+    static resetRollGetters(roll) {
+        roll._total = roll._evaluateTotal();
+        roll.resetFormula();
     }
 
     /**


### PR DESCRIPTION
Fixes an issue where applying retroactive advantage/disadvantage would incorrectly calculate the hit or miss indicators, and add duplicates.