### PR TITLE
feature/vanilla-rsr-cards

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -15,6 +15,8 @@
             "enableItemQuickRoll.hint": "When clicking on an item's image (weapons, spells, features, etc.), automatically roll to chat instead of using the normal chat output. This functionality can be bypassed by holding Alt when clicking.",
             "enableAltQuickRoll.name": "Enable Alternate Roll for Items",
             "enableAltQuickRoll.hint": "When Alt-clicking on an item's image, output a different quick roll which can be configured separately, replacing the ability to bypass quick rolling for items. This setting has no effect if item quick rolling is disabled.",
+            "enableVanillaQuickRoll.name": "Enable Content on Vanilla Rolls",
+            "enableVanillaQuickRoll.hint": "When outputting a vanilla roll, attempt to still apply module content, functionality, and styling. This setting will apply for any vanilla rolls, even those made by bypassing a quick roll by holding Alt.",
             "alwaysRollMulti.name": "Always Roll Multiple Dice",
             "alwaysRollMulti.hint": "When outputting a quick roll, always roll two dice (or three for Elven Accuracy) even when advantage/disadvantage is not applied.",
             "manualDamageMode.name": "Roll Damage Manually",

--- a/src/module/integration.js
+++ b/src/module/integration.js
@@ -1,0 +1,3 @@
+export const MODULE_AA = "autoanimations"
+export const MODULE_DAE = "dae";
+export const MODULE_DSN = "dice-so-nice";

--- a/src/module/integration.js
+++ b/src/module/integration.js
@@ -1,3 +1,4 @@
 export const MODULE_AA = "autoanimations"
+export const MODULE_RG = "rollgroups"
 export const MODULE_DAE = "dae";
 export const MODULE_DSN = "dice-so-nice";

--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -199,6 +199,10 @@ function _processVanillaMessage(message) {
 }
 
 async function _enforceDualRolls(message) {
+    if (message.rolls.length === 0) {
+        return;
+    }
+
     for (let i = 0; i < message.rolls.length; i++) {
         if (message.rolls[i] instanceof CONFIG.Dice.D20Roll) {
             message.rolls[i] = await RollUtility.ensureMultiRoll(message.rolls[i]);            

--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -224,18 +224,22 @@ async function _injectContent(message, type, html) {
             if (parent && message.isOwner) {
                 if (type === ROLL_TYPE.ATTACK) {
                     parent.flags[MODULE_SHORT].renderAttack = true;
-                    parent.flags[MODULE_SHORT].isCritical = parent.flags[MODULE_SHORT].dual ? false : message.rolls[0].isCritical;
                 }
 
                 if (type === ROLL_TYPE.DAMAGE) {
                     parent.flags[MODULE_SHORT].renderDamage = true;
                     parent.flags[MODULE_SHORT].versatile = message.flags.dnd5e.roll.versatile ?? false;
+                    parent.flags[MODULE_SHORT].isCritical = message.rolls[0]?.isCritical;
                 }
                 
                 if (type === ROLL_TYPE.TOOL) {
                     parent.flags[MODULE_SHORT].renderToolCheck = true;                     
                 }
                 
+                if (game.dice3d) {
+                    await CoreUtility.waitUntil(() => !message._dice3danimating);
+                }
+
                 parent.flags[MODULE_SHORT].quickRoll = true;
                 parent.rolls.push(...message.rolls);
 
@@ -261,12 +265,6 @@ async function _injectContent(message, type, html) {
             html.find('.dice-total').replaceWith(render);
             html.find('.dice-tooltip').prepend(html.find('.dice-formula'));
             break;
-        case ROLL_TYPE.ATTACK:
-        case ROLL_TYPE.DAMAGE:
-            if (!parent) {
-                return;
-            }
-            return;
         case ROLL_TYPE.ITEM:
             const actions = html.find('.card-buttons');
 

--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -42,11 +42,16 @@ export class ChatUtility {
             return;
         }
 
-        if (!message.flags || !message.flags[MODULE_SHORT]) {
+        if (!message.flags) {
             return;
         }
 
-        if (!message.flags[MODULE_SHORT].quickRoll) {
+        if (message.isRoll && SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_VANILLA_ENABLED) && !message.flags[MODULE_SHORT]) {
+            _processVanillaMessage(message)
+            return;
+        }
+
+        if (!message.flags[MODULE_SHORT] || !message.flags[MODULE_SHORT].quickRoll) {
             return;
         }
 
@@ -102,7 +107,8 @@ export class ChatUtility {
     }
 
     static isMessageMultiRoll(message) {
-        return (message.flags[MODULE_SHORT].advantage || message.flags[MODULE_SHORT].disadvantage || message.flags[MODULE_SHORT].dual) ?? false;
+        return (message.flags[MODULE_SHORT].advantage || message.flags[MODULE_SHORT].disadvantage || message.flags[MODULE_SHORT].dual
+            || (message.rolls[0] instanceof CONFIG.Dice.D20Roll && message.rolls[0].options.advantageMode !== CONFIG.Dice.D20Roll.ADV_MODE.NORMAL)) ?? false;
     }
 
     static isMessageCritical(message) {
@@ -157,6 +163,16 @@ function _onTooltipHoverEnd(html) {
         html.parent().removeAttr("style");
         html.parent()[0].style.height = `${html.parent()[0].scrollHeight}px`
     }
+}
+
+function _processVanillaMessage(message) {
+    message.flags[MODULE_SHORT] = {}
+    message.flags[MODULE_SHORT].quickRoll = true;
+    message.flags[MODULE_SHORT].processed = true;
+
+    ChatUtility.updateChatMessage(message, {
+        flags: message.flags
+    })
 }
 
 /**

--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -195,6 +195,7 @@ function _processVanillaMessage(message) {
     message.flags[MODULE_SHORT] = {};
     message.flags[MODULE_SHORT].quickRoll = true;
     message.flags[MODULE_SHORT].processed = true;
+    message.flags[MODULE_SHORT].useConfig = false;
 }
 
 async function _enforceDualRolls(message) {

--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -49,6 +49,7 @@ export class ChatUtility {
 
         if (SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_VANILLA_ENABLED) && !message.flags[MODULE_SHORT]) {
             _processVanillaMessage(message);
+            $(html).addClass("rsr-hide");
         }
 
         if (!message.flags[MODULE_SHORT] || !message.flags[MODULE_SHORT].quickRoll) {
@@ -193,6 +194,7 @@ function _setupCardListeners(message, html) {
 function _processVanillaMessage(message) {
     message.flags[MODULE_SHORT] = {};
     message.flags[MODULE_SHORT].quickRoll = true;
+    message.flags[MODULE_SHORT].processed = true;
 }
 
 async function _enforceDualRolls(message) {
@@ -220,28 +222,28 @@ async function _injectContent(message, type, html) {
         case ROLL_TYPE.TOOL:
             if (parent && message.isOwner) {
                 if (type === ROLL_TYPE.ATTACK) {
-                    parent.flags[MODULE_SHORT].hasAttack = true;
+                    parent.flags[MODULE_SHORT].renderAttack = true;
                     parent.flags[MODULE_SHORT].isCritical = parent.flags[MODULE_SHORT].dual ? false : message.rolls[0].isCritical;
                 }
 
                 if (type === ROLL_TYPE.DAMAGE) {
-                    parent.flags[MODULE_SHORT].hasDamage = true;
+                    parent.flags[MODULE_SHORT].renderDamage = true;
                     parent.flags[MODULE_SHORT].versatile = message.flags.dnd5e.roll.versatile ?? false;
                 }
                 
                 if (type === ROLL_TYPE.TOOL) {
-                    parent.flags[MODULE_SHORT].hasToolCheck = true;                     
+                    parent.flags[MODULE_SHORT].renderToolCheck = true;                     
                 }
                 
                 parent.flags[MODULE_SHORT].quickRoll = true;
                 parent.rolls.push(...message.rolls);
-                parent.flags[MODULE_SHORT].isContentVisible = message.isContentVisible;
 
                 ChatUtility.updateChatMessage(parent, {
                     flags: parent.flags,
                     rolls: parent.rolls,
                 });
 
+                message.flags[MODULE_SHORT].processed = false;
                 message.delete();
                 return;
             }

--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -290,10 +290,17 @@ async function _injectContent(message, html) {
                 actions.find(`[data-action='${ROLL_TYPE.ATTACK}']`).remove();
                 await _injectAttackRoll(message, actions);
             }
-
-            if (message.flags[MODULE_SHORT].hasDamage) {
+            
+            if (message.flags[MODULE_SHORT].manualDamage || message.flags[MODULE_SHORT].hasDamage) {                
                 actions.find(`[data-action='${ROLL_TYPE.DAMAGE}']`).remove();
                 actions.find(`[data-action='${ROLL_TYPE.VERSATILE}']`).remove();
+            }
+
+            if (message.flags[MODULE_SHORT].manualDamage) {
+                await _injectDamageButton(message, actions);
+            }
+
+            if (message.flags[MODULE_SHORT].hasDamage) {
                 await _injectDamageRoll(message, actions);
             }
 
@@ -602,9 +609,11 @@ async function _processRetroAdvButtonEvent(message, event) {
             flags: message.flags,
             rolls: message.rolls,
             flavor: message.flavor
-        });        
+        });
 
-        CoreUtility.playRollSound();
+        if (!game.dice3d) {
+            CoreUtility.playRollSound();
+        }
     }
 }
 
@@ -647,8 +656,10 @@ async function _processRetroCritButtonEvent(message, event) {
         await ChatUtility.updateChatMessage(message, {
             flags: message.flags,
             rolls: message.rolls
-        });       
+        });
 
-        CoreUtility.playRollSound();
+        if (!game.dice3d) {
+            CoreUtility.playRollSound();
+        }
     }
 }

--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -38,11 +38,13 @@ export class CoreUtility {
 
         switch(mode) {
             case 0:
-                return event.shiftKey ? 1 : (event.ctrlKey || event.metaKey ? -1 : 0);
+                return event.shiftKey ? CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE 
+                    : (event.ctrlKey || event.metaKey ? CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE : CONFIG.Dice.D20Roll.ADV_MODE.NORMAL);
             case 1:
-                return event.shiftKey ? -1 : (event.ctrlKey || event.metaKey ? 1 : 0);
+                return event.shiftKey ? CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE
+                    : (event.ctrlKey || event.metaKey ? CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE  : CONFIG.Dice.D20Roll.ADV_MODE.NORMAL);
             default:
-                return 0;
+                return CONFIG.Dice.D20Roll.ADV_MODE.NORMAL;
         }
     }
 

--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -93,6 +93,17 @@ export class CoreUtility {
         return game.modules.get(name)?.active;
     }
 
+    static isVisible(chatData) {
+        const whisper = chatData.whisper || [];
+        const isBlind = whisper.length && chatData.blind;
+
+        if ( whisper.length ) {
+            return whisper.includes(game.user.id) || (chatData.user.isSelf && !isBlind);
+        } 
+
+        return true;
+    }
+
     /**
      * Gets data about whispers and roll mode for use in rendering messages.
      * @param {*} rollMode 

--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -64,7 +64,7 @@ export class CoreUtility {
      * @param {Roll} rolls The roll objects to roll 3D dice for.
      * @returns {Promise<Boolean>} Whether or not 3D dice were actually rolled.
      */
-    static async tryRollDice3D(rolls) {
+    static async tryRollDice3D(rolls, messageID = null) {
         rolls = Array.isArray(rolls) ? rolls : [ rolls ];
 
         const promises = [];
@@ -75,7 +75,7 @@ export class CoreUtility {
 
             if (game.dice3d && hasDice) {
                 const whisperData = CoreUtility.getWhisperData();
-                promises.push(Promise.resolve(game.dice3d.showForRoll(roll, game.user, true, whisperData.whisper, whisperData.blind || false, null, whisperData.speaker)));
+                promises.push(Promise.resolve(game.dice3d.showForRoll(roll, game.user, true, whisperData.whisper, whisperData.blind || false, messageID, whisperData.speaker)));
             }
 		});
 
@@ -129,7 +129,33 @@ export class CoreUtility {
 		return { rollMode, whisper, blind }
 	}
 
+    /**
+     * Gets the default configured dice sound from Foundry VTT config.
+     * @returns 
+     */
+    static getRollSound() {
+        let sound = undefined;
+
+        if (!CoreUtility._lockRollSound && SettingsUtility.getSettingValue(SETTING_NAMES.DICE_SOUNDS_ENABLED)) {
+            CoreUtility._lockRollSound = true;
+            setTimeout(() => CoreUtility._lockRollSound = false, 300);
+            
+            sound = CONFIG.sounds.dice;
+        }
+
+        return { sound }
+    }
+
     static playRollSound() {
         AudioHelper.play({src: CONFIG.sounds.dice });
+    }
+
+    static async waitUntil(condition) {
+        const poll = resolve => {
+            if (condition()) resolve();
+            else setTimeout(_ => poll(resolve), 100);
+        }
+
+        return new Promise(poll);
     }
 }

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -1,5 +1,7 @@
 import { MODULE_SHORT, MODULE_TITLE } from "../module/const.js";
+import { MODULE_DSN } from "../module/integration.js";
 import { ChatUtility } from "./chat.js";
+import { CoreUtility } from "./core.js";
 import { ItemUtility } from "./item.js";
 import { LogUtility } from "./log.js";
 import { RollUtility } from "./roll.js";
@@ -24,6 +26,10 @@ export const HOOKS_DND5E = {
     RENDER_CHAT_MESSAGE: "dnd5e.renderChatMessage",    
     RENDER_ITEM_SHEET: "renderItemSheet5e",
     RENDER_ACTOR_SHEET: "renderActorSheet5e",
+}
+
+export const HOOKS_INTEGRATION = {
+    DSN_ROLL_COMPLETE: "diceSoNiceRollComplete"
 }
 
 /**
@@ -51,6 +57,7 @@ export class HooksUtility {
             );
 
             HooksUtility.registerSheetHooks();
+            HooksUtility.registerIntegrationHooks();
 
             LogUtility.log(`Loaded ${MODULE_TITLE}`);
         });
@@ -105,13 +112,17 @@ export class HooksUtility {
                 return true;
             });
 
-            Hooks.on(HOOKS_DND5E.PRE_ROLL_DAMAGE, (item, config) => {
-                ItemUtility.processItemDamageConfig(item, config);
-                return true;
+            Hooks.on(HOOKS_DND5E.PRE_DISPLAY_CARD, async (item, card, options) => {
+                ItemUtility.setRenderFlags(item, card);
             });
 
             Hooks.on(HOOKS_DND5E.DISPLAY_CARD, async (item, card) => {
-                await ItemUtility.runItemActions(card);
+                ItemUtility.runItemActions(item, card);
+            });
+
+            Hooks.on(HOOKS_DND5E.PRE_ROLL_DAMAGE, (item, config) => {
+                ItemUtility.processItemDamageConfig(item, config);
+                return true;
             });
         }
     }
@@ -142,6 +153,16 @@ export class HooksUtility {
             ItemSheet.prototype._onChangeTab = function _onChangeTab(event, tabs, active) {
                 SheetUtility.setAutoHeightOnSheet(this);
             }
+        }
+    }
+
+    static registerIntegrationHooks() {
+        LogUtility.log("Registering integration hooks");
+
+        if (CoreUtility.hasModule(MODULE_DSN)) {
+            Hooks.on(HOOKS_INTEGRATION.DSN_ROLL_COMPLETE, (id) => {
+                console.log(id);
+            });
         }
     }
 }

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -158,11 +158,5 @@ export class HooksUtility {
 
     static registerIntegrationHooks() {
         LogUtility.log("Registering integration hooks");
-
-        if (CoreUtility.hasModule(MODULE_DSN)) {
-            Hooks.on(HOOKS_INTEGRATION.DSN_ROLL_COMPLETE, (id) => {
-                console.log(id);
-            });
-        }
     }
 }

--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -87,6 +87,7 @@ export class ItemUtility {
     static async runItemActions(item, card) {
         if (card.flags[MODULE_SHORT].renderAttack && item.hasAttack) {
             const attackRoll = await ItemUtility.getAttackFromCard(item, card);
+            card.flags[MODULE_SHORT].isCritical = card.flags[MODULE_SHORT].dual ? false : attackRoll.isCritical
             card.rolls.push(attackRoll);
         }
 
@@ -106,8 +107,12 @@ export class ItemUtility {
 
         ChatUtility.updateChatMessage(card, { 
             flags: card.flags,
-            rolls: card.rolls
+            rolls: card.rolls,
         });
+
+        if (!game.dice3d) {
+            CoreUtility.playRollSound();
+        }
     }
 
     static async runItemAction(item, card, action) {

--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -39,6 +39,7 @@ export class ItemUtility {
         ItemUtility.ensureFlagsOnItem(item);
 
         card.flags[MODULE_SHORT].name = item.name;
+        card.flags[MODULE_SHORT].useConfig = true;
         card.flags[MODULE_SHORT].isHealing = item.isHealing;
 
         if (!ItemUtility.getFlagValueFromItem(item, "quickFooter", card.flags[MODULE_SHORT].altRoll)) {
@@ -179,7 +180,8 @@ export class ItemUtility {
                 altRoll: card.flags[MODULE_SHORT].altRoll,
                 messageData: {
                     "flags.dnd5e.originatingMessage": card.id,
-                    "flags.rsr5e.quickRoll": true
+                    "flags.rsr5e.quickRoll": true,
+                    "flags.rsr5e.useConfig": card.flags[MODULE_SHORT].useConfig
                 }
             }
         });
@@ -192,6 +194,10 @@ export class ItemUtility {
      */
     static processItemDamageConfig(item, config) {
         if (!config.messageData[`flags.${MODULE_SHORT}.quickRoll`]) {
+            return;
+        }
+
+        if (!config.messageData[`flags.${MODULE_SHORT}.useConfig`]) {
             return;
         }
         

--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -72,15 +72,15 @@ export class ItemUtility {
             await _runToolCheck(item, card);
         }
 
-        await CoreUtility.tryRollDice3D(card.rolls);
-
         card.flags[MODULE_SHORT].processed = true;
 
         ChatUtility.updateChatMessage(card, { 
             flags: card.flags
         });
 
-        CoreUtility.playRollSound();
+        if (!game.dice3d) {
+            CoreUtility.playRollSound();
+        }
     }
 
     static async runItemAction(card, action) {
@@ -101,13 +101,13 @@ export class ItemUtility {
                 break;
         }
 
-        await CoreUtility.tryRollDice3D(card.rolls);
-
         ChatUtility.updateChatMessage(card, { 
             flags: card.flags
         });
 
-        CoreUtility.playRollSound();
+        if (!game.dice3d) {
+            CoreUtility.playRollSound();
+        }
     }
 
     /**

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -57,8 +57,7 @@ export class RollUtility {
         config.disadvantage = advMode === CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE;
 
         config.messageData[`flags.${MODULE_SHORT}`] = { 
-            quickRoll: SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_VANILLA_ENABLED) || !ignore,
-            processed: true
+            quickRoll: SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_VANILLA_ENABLED) || !ignore
         };
     }
 
@@ -70,14 +69,14 @@ export class RollUtility {
         const ignore = (window.event.altKey && !altRoll) ?? false;
 
         options.fastForward = !ignore;
-        config.advantage = advMode === CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;
-        config.disadvantage = advMode === CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE;
+        options.advantage = advMode === CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;
+        options.disadvantage = advMode === CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE;
 
         options.flags[MODULE_SHORT] = { 
             quickRoll: !ignore,
             advantage: options.advantage,
             disadvantage: options.disadvantage,
-            altRoll: altRoll
+            altRoll: altRoll && !ignore
         };
     }
 

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -57,7 +57,8 @@ export class RollUtility {
         config.disadvantage = advMode === CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE;
 
         config.messageData[`flags.${MODULE_SHORT}`] = { 
-            quickRoll: SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_VANILLA_ENABLED) || !ignore
+            quickRoll: SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_VANILLA_ENABLED) || !ignore,
+            processed: true
         };
     }
 

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -53,13 +53,11 @@ export class RollUtility {
         const ignore = config.event?.altKey ?? false;
 
         config.fastForward = !ignore;
-        config.advantage = advMode > 0;
-        config.disadvantage = advMode < 0;
+        config.advantage = advMode === CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;
+        config.disadvantage = advMode === CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE;
 
         config.messageData[`flags.${MODULE_SHORT}`] = { 
-            quickRoll: !ignore,
-            advantage: config.advantage,
-            disadvantage: config.disadvantage,
+            quickRoll: SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_VANILLA_ENABLED) || !ignore,
             processed: true
         };
     }
@@ -72,8 +70,8 @@ export class RollUtility {
         const ignore = (window.event.altKey && !altRoll) ?? false;
 
         options.fastForward = !ignore;
-        options.advantage = advMode > 0;
-        options.disadvantage = advMode < 0;
+        config.advantage = advMode === CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;
+        config.disadvantage = advMode === CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE;
 
         options.flags[MODULE_SHORT] = { 
             quickRoll: !ignore,

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -13,6 +13,7 @@ export const SETTING_NAMES = {
     QUICK_DEATH_ENABLED: "enableDeathQuickRoll",
     QUICK_TOOL_ENABLED: "enableToolQuickRoll",
     QUICK_ITEM_ENABLED: "enableItemQuickRoll",
+    QUICK_VANILLA_ENABLED: "enableVanillaQuickRoll",
     ALT_ROLL_ENABLED: "enableAltQuickRoll",
     ALWAYS_ROLL_MULTIROLL: "alwaysRollMulti",
     D20_ICONS_ENABLED: "enableD20Icons",
@@ -54,7 +55,8 @@ export class SettingsUtility {
             { name: SETTING_NAMES.QUICK_SKILL_ENABLED, default: true },
             { name: SETTING_NAMES.QUICK_DEATH_ENABLED, default: true },
             { name: SETTING_NAMES.QUICK_TOOL_ENABLED, default: true },
-            { name: SETTING_NAMES.QUICK_ITEM_ENABLED, default: true }
+            { name: SETTING_NAMES.QUICK_ITEM_ENABLED, default: true },
+            { name: SETTING_NAMES.QUICK_VANILLA_ENABLED, default: false }
         ];
 
         quickRollOptions.forEach(option => {

--- a/templates/rsr-section.html
+++ b/templates/rsr-section.html
@@ -1,4 +1,4 @@
-<section class="card-header description {{#if critical}}critical{{/if}}">
+<section class="card-header description {{#if critical}}critical{{/if}} {{section}}">
     <div class = "rsr-header">
         <div class="rsr-title">
             {{{icon}}}{{title}}


### PR DESCRIPTION
Adds the option to integrate module chat card content (for example, damage apply buttons and overlays) into vanilla rolls if possible. Any child messages created by a vanilla chat card (specifically, for items) will be intercepted and added into the original message instead of displaying as its own card. Any multirolls in vanilla chat cards will properly display all internal rolls, and force dual rolls if the setting is appropriately enabled.

Fixes #244.