### PR TITLE
feature/apply-total-damage

### DIFF
--- a/css/ready-set-roll.css
+++ b/css/ready-set-roll.css
@@ -80,9 +80,13 @@
 	position: relative;
 }
 
-.rsr-damage-buttons {
+.rsr-damage-buttons,
+.rsr-damage-buttons-xl {
 	text-align: right!important;
 	display: flex;
+}
+
+.rsr-damage-buttons {
 	justify-content: center;
 	align-items: center;
 	padding-right: 8%;
@@ -97,12 +101,30 @@
 	gap: 0;
 }
 
-.rsr-damage-buttons button.rsr-wide {
+.rsr-damage-buttons-xl {
+	justify-content: space-between;
+	align-items: center;
+	padding-right: 0;
+	padding-top: 5px;
+}
+
+.rsr-damage-buttons-xl button {
+	width: 32px;
+	height: 26px;
+	font-size: var(--font-size-14);
+	line-height: 26px;
+	padding: 0;
+	gap: 0;
+}
+
+.rsr-damage-buttons button.rsr-wide,
+.rsr-damage-buttons-xl button.rsr-wide {
 	width: auto;
 	padding: 0 3px;
 }
 
-.rsr-damage-buttons button > i {
+.rsr-damage-buttons button > i,
+.rsr-damage-buttons-xl button > i {
 	margin: 0;
 }
 

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -149,4 +149,24 @@ export class SettingsUtility {
     static getSettingValue(settingKey) {
         return game.settings.get(MODULE_NAME, settingKey);
     }
+    
+    static get _applyDamageToTargeted() {
+        const applyDamageOption = SettingsUtility.getSettingValue(SETTING_NAMES.APPLY_DAMAGE_TO);
+        return applyDamageOption === 1 || applyDamageOption >= 2;
+    }
+
+    static get _applyDamageToSelected() {
+        const applyDamageOption = SettingsUtility.getSettingValue(SETTING_NAMES.APPLY_DAMAGE_TO);
+        return applyDamageOption === 0 || applyDamageOption >= 2;
+    }
+
+    static get _prioritiseDamageTargeted() {
+        const applyDamageOption = SettingsUtility.getSettingValue(SETTING_NAMES.APPLY_DAMAGE_TO);
+        return applyDamageOption === 4;
+    }
+
+    static  get _prioritiseDamageSelected() {
+        const applyDamageOption = SettingsUtility.getSettingValue(SETTING_NAMES.APPLY_DAMAGE_TO);
+        return applyDamageOption === 3;
+    }
 }

--- a/templates/rsr-damage-buttons.html
+++ b/templates/rsr-damage-buttons.html
@@ -17,7 +17,7 @@
     <button class="rsr-wide" data-action="rsr-apply-damage" data-multiplier="1" title="{{ localize "rsr5e.chat.buttons.damageFull" }}">
         <i class="fas fa-burst"></i><i class="fa-solid fa-xmark"></i>1
     </button>
-    <div>
+    <div class="rsr-indicator">
         <i class="fas fa-reply-all fa-flip-vertical"></i>
     </div>
 </div>


### PR DESCRIPTION
Adds a row of apply damage buttons outside the tooltips that apply the total damage of the card. Damages are still computed individually with type and properties, so the usual system reductions for resistance/immunity are still applied correctly.

Implements #323.