### PR TITLE
bugfix/incorrect-target-value

### DIFF
--- a/src/utils/render.js
+++ b/src/utils/render.js
@@ -50,7 +50,7 @@ async function _renderMultiRoll(data = {}) {
         const critOptions = { 
             critThreshold: roll.options.critical,
             fumbleThreshold: roll.options.fumble,
-            targetValue: roll.options.targetValue
+            targetValue: roll.options.targetValue - (bonusRoll?.total ?? 0)
         };
 
         // Die terms must have active results or the base roll total of the generated roll is 0.


### PR DESCRIPTION
Fixes an issue where modifiers to a d20 roll would not be factored into the target DC calculation when deciding if the roll should display as a success or a failure.

Fixes #366.