### PR TITLE
bugfix/recover-item-from-token

### DIFF
--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -325,8 +325,15 @@ async function _ensureItemFromCard(card) {
     const Item5e = CONFIG.Item.documentClass;
 
     const itemId = card.flags.dnd5e.use.itemId;
-    const actor = game.actors.get(card.speaker.actor);
     const storedData = card.getFlag("dnd5e", "itemData");
+
+    let actor = null;
+    if (card.speaker.token) {
+        const token = game.scenes.get(card.speaker.scene).tokens.get(card.speaker.token);
+        actor = token?.actor;
+    } else if (card.speaker.actor) {
+        actor = game.actors.get(card.speaker.actor);
+    }
 
     return storedData && actor ? await Item5e.create(storedData, { parent: actor, temporary: true }) : actor?.items.get(itemId);
 }


### PR DESCRIPTION
Fixes an issue where unlinked tokens would still recover item data from the prototype actor instead of their token.  Fixes an issue where features added to unlinked tokens would not be able to roll.

Fixes #369.