### PR TITLE
feature/hide-redundant-chat-buttons

### DIFF
--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -557,6 +557,7 @@ async function _processApplyButtonEvent(message, event) {
     const button = event.currentTarget;
     const action = button.dataset.action;
     const multiplier = button.dataset.multiplier;
+    const dice = $(button).closest('.tooltip-part').find('.dice');
 
     if (action !== "rsr-apply-damage" && action !== "rsr-apply-temp") {
         return;
@@ -569,7 +570,7 @@ async function _processApplyButtonEvent(message, event) {
     }
 
     const isTempHP = action === "rsr-apply-temp";
-    const damage = _getApplyDamage(message, button);
+    const damage = _getApplyDamage(message, dice, multiplier);
 
     await Promise.all(Array.from(targets).map(async t => {
         const target = t.actor;        
@@ -604,11 +605,10 @@ async function _processApplyTotalButtonEvent(message, event) {
     const isTempHP = action === "rsr-apply-temp";
     const damages = [];
 
-    const children = $(button).closest('.dice-roll')
-        .find(`.rsr-damage .dice-tooltip .tooltip-part .rsr-damage-buttons button[data-action="${action}"][data-multiplier="${multiplier}"]`);
+    const children = $(button).closest('.dice-roll').find('.rsr-damage .dice-tooltip .tooltip-part .dice');
 
     children.each((i, el) => {
-        damages.push(_getApplyDamage(message, el));
+        damages.push(_getApplyDamage(message, $(el), multiplier));
     })
 
     await Promise.all(Array.from(targets).map(async t => {
@@ -625,11 +625,10 @@ async function _processApplyTotalButtonEvent(message, event) {
     }, 50);
 }
 
-function _getApplyDamage(message, button) {    
-    const multiplier = button.dataset.multiplier;
-    const dice = $(button).parent().siblings().find('.total')
-    const value = parseInt(dice.find('.value').text());
-    const type = dice.find('.label').text().toLowerCase();
+function _getApplyDamage(message, dice, multiplier) {
+    const total = dice.find('.total')
+    const value = parseInt(total.find('.value').text());
+    const type = total.find('.label').text().toLowerCase();
 
     const properties = new Set(message.rolls.find(r => r instanceof CONFIG.Dice.DamageRoll)?.options?.properties ?? []);
     return { value: value, type: multiplier < 0 ? 'healing' : type, properties: properties };

--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -455,7 +455,10 @@ async function _injectApplyDamageButtons(message, html) {
     const render = await RenderUtility.render(TEMPLATE.DAMAGE_BUTTONS, {});
 
     const tooltip = html.find('.rsr-damage .dice-tooltip .tooltip-part');
-    tooltip.append($(render));
+
+    if (tooltip.length > 1) {
+        tooltip.append($(render));
+    }
 
     const total = html.find('.rsr-damage');
     const renderXL = $(render);


### PR DESCRIPTION
Chat cards with only one damage tooltip will no longer show the apply damage buttons inside the tooltip, as they are redundant with the total damage apply buttons. Cards which have multiple damage types will still show the individual section apply buttons.

Resolves #370.