### PR TITLE
feature/add-optional-retro-dialogs

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -32,7 +32,11 @@
             "alwaysShowButtons.name": "Always Show Apply Buttons",
             "alwaysShowButtons.hint": "When outputting a quick roll chat card, always show the damage apply buttons, instead of only on hover.",
             "applyDamageTo.name": "Apply Damage Options",
-            "applyDamageTo.hint": "Determines which tokens damage is applied to when applying damage via the chat overlay buttons."
+            "applyDamageTo.hint": "Determines which tokens damage is applied to when applying damage via the chat overlay buttons.",
+            "confirmRetroAdv.name": "Confirm Retroactive Advantage",
+            "confirmRetroAdv.hint": "Show a confirmation dialog when retroactively changing a roll to advantage or disadvantage.",
+            "confirmRetroCrit.name": "Confirm Retroactive Crits",
+            "confirmRetroCrit.hint": "Show a confirmation dialog when retroactively changing a roll to critical damage."
         },
         "choices": {
             "rollModifierMode": {
@@ -81,6 +85,10 @@
                 "rollAdvantage": "Click to roll with advantage.",
                 "rollDisadvantage": "Click to roll with disadvantage.",
                 "repeat": "Click to repeat the quick roll."
+            },
+            "prompts": {
+                "retroCrit": "Upgrade to Crit?",
+                "retroAdv": "Roll {target}?"
             }
         },
         "messages": {

--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -1,6 +1,7 @@
 import { MODULE_SHORT } from "../module/const.js";
 import { TEMPLATE } from "../module/templates.js";
 import { CoreUtility } from "./core.js";
+import { DialogUtility } from "./dialog.js";
 import { ItemUtility } from "./item.js";
 import { LogUtility } from "./log.js";
 import { RenderUtility } from "./render.js";
@@ -650,6 +651,19 @@ async function _processRetroAdvButtonEvent(message, event) {
     const key = $(button).closest('.rsr-multiroll')[0].dataset.key;
 
     if (action === "rsr-retro") {
+        if (SettingsUtility.getSettingValue(SETTING_NAMES.CONFIRM_RETRO_ADV)) {        
+            const dialogOptions = {
+                width: 100,
+                top: event ? event.clientY - 50 : null,
+                left: window.innerWidth - 510
+            }
+    
+            const target = state === ROLL_STATE.ADV ? CoreUtility.localize("DND5E.Advantage") : CoreUtility.localize("DND5E.Disadvantage");
+            const confirmed = await DialogUtility.getConfirmDialog(CoreUtility.localize(`${MODULE_SHORT}.chat.prompts.retroAdv`, { target }), dialogOptions);
+    
+            if (!confirmed) return;
+        }
+        
         message.flags[MODULE_SHORT].advantage = state === ROLL_STATE.ADV;
         message.flags[MODULE_SHORT].disadvantage = state === ROLL_STATE.DIS;
 
@@ -688,6 +702,18 @@ async function _processRetroCritButtonEvent(message, event) {
     const action = button.dataset.action;
 
     if (action === "rsr-retro") {
+        if (SettingsUtility.getSettingValue(SETTING_NAMES.CONFIRM_RETRO_CRIT)) {        
+            const dialogOptions = {
+                width: 100,
+                top: event ? event.clientY - 50 : null,
+                left: window.innerWidth - 510
+            }
+    
+            const confirmed = await DialogUtility.getConfirmDialog(CoreUtility.localize(`${MODULE_SHORT}.chat.prompts.retroCrit`), dialogOptions);
+    
+            if (!confirmed) return;
+        }
+        
         message.flags[MODULE_SHORT].isCritical = true;
 
         const rolls = message.rolls.filter(r => r instanceof CONFIG.Dice.DamageRoll);

--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -180,7 +180,7 @@ export class CoreUtility {
     static async waitUntil(condition) {
         const poll = resolve => {
             if (condition()) resolve();
-            else setTimeout(_ => poll(resolve), 100);
+            else setTimeout(_ => poll(resolve), 10);
         }
 
         return new Promise(poll);
@@ -193,7 +193,7 @@ export class CoreUtility {
      */
     static async waitWhile(condition) {
         const poll = resolve => {
-            if (condition()) setTimeout(_ => poll(resolve), 100);
+            if (condition()) setTimeout(_ => poll(resolve), 10);
             else resolve();
         }
 

--- a/src/utils/dialog.js
+++ b/src/utils/dialog.js
@@ -1,0 +1,30 @@
+import { CoreUtility } from "./core.js";
+
+/**
+ * Utility class for handing configuration dialogs.
+ */
+export class DialogUtility {
+    static getConfirmDialog(title, options) {
+        return new Promise(resolve => { 
+            const data = {
+                title,
+                content: "",
+                buttons: {
+                    yes: {
+                        icon: '<i class="fa-solid fa-check"></i>',
+                        label: CoreUtility.localize("Yes"),
+                        callback: () => { resolve(true); }
+                    },
+                    no: {
+                        icon: '<i class="fa-solid fa-xmark"></i>',
+                        label: CoreUtility.localize("No"),
+                        callback: () => { resolve(false); }
+                    }
+                },
+                default: "yes"
+            }
+
+            new Dialog(data, options).render(true);
+        });
+    }
+}

--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -313,8 +313,6 @@ export class ItemUtility {
             if (index < (itemPartsCount + ammoPartsCount)) {
                 return consumeTarget?.name;
             }
-
-            //return CoreUtility.localize(`${MODULE_SHORT}.chat.bonus.bonus`);
         }
 
         return undefined;

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -24,6 +24,8 @@ export const SETTING_NAMES = {
     DICE_REROLL_ENABLED: "enableDiceReroll",
     APPLY_DAMAGE_TO: "applyDamageTo",
     ALWAYS_ROLL_MULTIROLL: "alwaysRollMulti",
+    CONFIRM_RETRO_ADV: "confirmRetroAdv",
+    CONFIRM_RETRO_CRIT: "confirmRetroCrit"
 }
 
 /**
@@ -109,6 +111,8 @@ export class SettingsUtility {
             { name: SETTING_NAMES.OVERLAY_BUTTONS_ENABLED, default: true },
             { name: SETTING_NAMES.DAMAGE_BUTTONS_ENABLED, default: true },
             { name: SETTING_NAMES.ALWAYS_SHOW_BUTTONS, default: false },
+            { name: SETTING_NAMES.CONFIRM_RETRO_ADV, default: false },
+            { name: SETTING_NAMES.CONFIRM_RETRO_CRIT, default: false },
         ]        
 
         chatCardOptions.forEach(option => {


### PR DESCRIPTION
Adds optional confirmation dialogs (enabled via the settings) when clicking retroactive advantage, disadvantage, or crit buttons, for those wishing to avoid misclicks.

Resolves #355.