### PR TITLE
bugfix/user-permission-updates

### DIFF
--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -50,7 +50,7 @@ export class ChatUtility {
         }
         
         // This will force dual rolls on non-item messages, since this is the only place we can catch this before it is displayed.
-        if (SettingsUtility.getSettingValue(SETTING_NAMES.ALWAYS_ROLL_MULTIROLL) && !ChatUtility.isMessageMultiRoll(message)) {
+        if (message.isOwner && SettingsUtility.getSettingValue(SETTING_NAMES.ALWAYS_ROLL_MULTIROLL) && !ChatUtility.isMessageMultiRoll(message)) {
             await _enforceDualRolls(message);
 
             if (message.flags[MODULE_SHORT].dual) {


### PR DESCRIPTION
Fixes an issue where chat messages would try to enforce dual rolls for messages that did not belong to them, causing every client to try and independently force dual rolls on the same message.

Fixes #380, and probably also #362 + #363.