### PR TITLE
bugfix/fix-tool-item-rolls

### DIFF
--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -91,7 +91,7 @@ export class ItemUtility {
             card.rolls.push(attackRoll);
         }
 
-        if (card.flags[MODULE_SHORT].renderToolCheck && item.type !== ITEM_TYPE.TOOL) {
+        if (card.flags[MODULE_SHORT].renderToolCheck && item.type === ITEM_TYPE.TOOL) {
             const toolCheckRoll = await ItemUtility.getToolCheckFromCard(card);
             card.rolls.push(toolCheckRoll);
         }


### PR DESCRIPTION
Fix an issue where tools wouldn't properly calculate a quick roll when rolled as an item.