### PR TITLE
bugfix/concentration-save-advmode

### DIFF
--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -53,8 +53,8 @@ export class RollUtility {
         const ignore = config.event?.altKey ?? false;
 
         config.fastForward = !ignore;
-        config.advantage ??= advMode === CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;
-        config.disadvantage ??= advMode === CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE;
+        config.advantage ||= advMode === CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;
+        config.disadvantage ||= advMode === CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE;
 
         config.messageData[`flags.${MODULE_SHORT}`] = { 
             quickRoll: SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_VANILLA_ENABLED) || !ignore,
@@ -70,8 +70,8 @@ export class RollUtility {
         const ignore = (window.event.altKey && !altRoll) ?? false;
 
         options.fastForward = !ignore;
-        options.advantage ??= advMode === CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;
-        options.disadvantage ??= advMode === CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE;
+        options.advantage ||= advMode === CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;
+        options.disadvantage ||= advMode === CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE;
 
         options.flags[MODULE_SHORT] = { 
             quickRoll: !ignore,


### PR DESCRIPTION
Fix an issue in dnd5e 3.1 where concentration save prompts wouldn't correctly parse RSR advantage key modifiers.

Progresses #411.