### PR TITLE
bugfix/3.1-item-roll-fast-forwarding

### DIFF
--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -57,7 +57,7 @@ export class ItemUtility {
         if (ItemUtility.getFlagValueFromItem(item, "quickAttack", card.flags[MODULE_SHORT].altRoll)) {
             card.flags[MODULE_SHORT].renderAttack = true;            
             card.flags[MODULE_SHORT].consume = _getConsumeTargetFromItem(item)?.name;
-            card.flags.dnd5e.targets = item._formatAttackTargets();
+            card.flags.dnd5e.targets = CONFIG.Item.documentClass._formatAttackTargets();
         } else if (item.hasAttack) {
             card.flags[MODULE_SHORT].renderAttack = false;
         }


### PR DESCRIPTION
Fix an issue in dnd5e 3.1 where item rolls wouldn't succeed in rolling damage due to a change in a dnd5e function.

Progresses #411.