### PR TITLE
bugfix/3.1-apply-button-collapsing-issues

### DIFF
--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -147,7 +147,6 @@ function _onTooltipHover(message, html) {
     if (controlled || targeted) {
         html.find('.rsr-damage-buttons').show();
         html.find('.rsr-damage-buttons').removeAttr("style");
-        html.parent()[0].style.height = `${html.parent()[0].scrollHeight}px`
     }
 }
 
@@ -158,11 +157,6 @@ function _onTooltipHover(message, html) {
  */
 function _onTooltipHoverEnd(html) {
     html.find(".rsr-damage-buttons").attr("style", "display: none;height: 0px");
-
-    if (html.parent()[0].style.height !== '0px') {        
-        html.parent().removeAttr("style");
-        html.parent()[0].style.height = `${html.parent()[0].scrollHeight}px`
-    }
 }
 
 function _onDamageHover(message, html) {

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -110,7 +110,7 @@ export class SettingsUtility {
             { name: SETTING_NAMES.DICE_REROLL_ENABLED, default: true },
             { name: SETTING_NAMES.OVERLAY_BUTTONS_ENABLED, default: true },
             { name: SETTING_NAMES.DAMAGE_BUTTONS_ENABLED, default: true },
-            { name: SETTING_NAMES.ALWAYS_SHOW_BUTTONS, default: false },
+            { name: SETTING_NAMES.ALWAYS_SHOW_BUTTONS, default: true },
             { name: SETTING_NAMES.CONFIRM_RETRO_ADV, default: false },
             { name: SETTING_NAMES.CONFIRM_RETRO_CRIT, default: false },
         ]        


### PR DESCRIPTION
Fix an issue in dnd5e 3.1 where apply damage hover buttons would break tooltip collapsing.

Progresses #411.