### PR TITLE
bugfix/manual-damage-rolling

### DIFF
--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -63,10 +63,11 @@ export class ItemUtility {
         }
         
         const manualDamageMode = SettingsUtility.getSettingValue(SETTING_NAMES.MANUAL_DAMAGE_MODE);
-        card.flags[MODULE_SHORT].manualDamage = item.hasDamage && (manualDamageMode === 2 || (manualDamageMode === 1 && item.hasAttack));
 
-        if (!card.flags[MODULE_SHORT].manualDamage) {
-            card.flags[MODULE_SHORT].renderDamage = true;            
+        if (item.hasDamage)
+        {
+            card.flags[MODULE_SHORT].manualDamage = (manualDamageMode === 2 || (manualDamageMode === 1 && item.hasAttack));
+
             card.flags[MODULE_SHORT].versatile = item.isVersatile ? ItemUtility.getFlagValueFromItem(item, "quickVersatile", card.flags[MODULE_SHORT].altRoll) : false;
             card.flags[MODULE_SHORT].context = [];
                 
@@ -77,6 +78,10 @@ export class ItemUtility {
                     card.flags[MODULE_SHORT].context.push(ItemUtility.getDamageContextFromItem(item, i));
                 }
             }
+        }
+
+        if (!card.flags[MODULE_SHORT].manualDamage) {
+            card.flags[MODULE_SHORT].renderDamage = true;
         }
 
         if (item.type === ITEM_TYPE.TOOL) {


### PR DESCRIPTION
Fixes a couple of issues with manual damage rolling where context and versatile flags were not correctly generated and thus ignored when rolling damage manually.

Fixes #434 and #430.