### PR TITLE
internal/aggregate-damage-prepwork

### DIFF
--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -56,6 +56,10 @@ export class HooksUtility {
                 { recursive: false }
             );
 
+            if (SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_ITEM_ENABLED)) { 
+                CONFIG.DND5E.aggregateDamageDisplay = false;
+            }
+
             HooksUtility.registerSheetHooks();
             HooksUtility.registerIntegrationHooks();
 


### PR DESCRIPTION
Implements the CONFIG option for disabling aggregate damage in RSR when item quick rolls are enabled. This will do nothing until https://github.com/foundryvtt/dnd5e/pull/3885 is merged.