### PR TITLE
feature/target-value-icons

### DIFF
--- a/src/utils/render.js
+++ b/src/utils/render.js
@@ -76,12 +76,15 @@ async function _renderMultiRoll(data = {}) {
         });
         const baseRoll = Roll.fromTerms([baseTerm]);
 
+        const total = baseRoll.total + (bonusRoll?.total ?? 0);
+
         entries.push({
 			roll: baseRoll,
-			total: baseRoll.total + (bonusRoll?.total ?? 0),
+			total: total,
 			ignored: tmpResults.some(r => r.discarded) ? true : undefined,
             critType: RollUtility.getCritTypeForDie(baseTerm, critOptions),
-            d20Result: SettingsUtility.getSettingValue(SETTING_NAMES.D20_ICONS_ENABLED) ? d20Rolls.results[i].result : null
+            d20Result: SettingsUtility.getSettingValue(SETTING_NAMES.D20_ICONS_ENABLED) ? d20Rolls.results[i].result : null,
+            dcResult: isNaN(critOptions.targetValue) ? undefined : (total >= critOptions.targetValue ? "fas fa-check" : "fas fa-xmark")
 		});
     }
 

--- a/templates/rsr-multiroll.html
+++ b/templates/rsr-multiroll.html
@@ -1,7 +1,9 @@
 <div class="rsr-multiroll" data-key="{{key}}">
     {{#each entries}}
     <h4 class="dice-total {{#if this.ignored}}ignored{{/if}} {{this.critType}}">
-        {{this.total}}{{#if this.d20Result}}<span class="die-icon {{this.critType}}">{{this.d20Result}}</span>{{/if}}
+        {{this.total}}
+        {{#if this.d20Result}}<span class="die-icon {{this.critType}}">{{this.d20Result}}</span>{{/if}}
+        {{#if this.dcResult}}<div class="icons"><i class="{{this.dcResult}}" inert=""></i></div>{{/if}}
     </h4>
     {{/each}}
 </div>


### PR DESCRIPTION
Adds in support for base system functionality where a check mark or x-mark are shown  for success or failure respectively when a roll has a target value. This should work for each independent roll in a multi roll.