### PR TITLE
bugfix/hide-dc-indicator-icons

### DIFF
--- a/src/utils/render.js
+++ b/src/utils/render.js
@@ -84,7 +84,7 @@ async function _renderMultiRoll(data = {}) {
 			ignored: tmpResults.some(r => r.discarded) ? true : undefined,
             critType: RollUtility.getCritTypeForDie(baseTerm, critOptions),
             d20Result: SettingsUtility.getSettingValue(SETTING_NAMES.D20_ICONS_ENABLED) ? d20Rolls.results[i].result : null,
-            dcResult: isNaN(critOptions.targetValue) ? undefined : (total >= critOptions.targetValue ? "fas fa-check" : "fas fa-xmark")
+            dcResult: !critOptions.displayChallenge || isNaN(critOptions.targetValue) ? undefined : (total >= critOptions.targetValue ? "fas fa-check" : "fas fa-xmark")
 		});
     }
 


### PR DESCRIPTION
Fixes an issue where rolls originating from action buttons with hidden DCs would still show the icon that indicated where the DC had passed or not.