### PR TITLE
bugfix/duplicate-targets-tray

### DIFF
--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -401,7 +401,7 @@ async function _injectAttackRoll(message, html) {
 
     // Remove and re-add enrichers for hit/miss indication
     const card = html.closest('.chat-message');
-    card.find('.evaluation').remove();
+    card.find('.targets-tray').parent().remove();
     message._enrichAttackTargets(card[0]);
 }
 


### PR DESCRIPTION
Fixes an issue where the original targets tray was not correctly being removed for attacks before adding a new target-tray with the correct targets.

Fixes #459.