### PR TITLE
bugfix/duplicate-vanilla-rolls

### DIFF
--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -280,7 +280,10 @@ async function _injectContent(message, type, html) {
                 }
 
                 parent.flags[MODULE_SHORT].quickRoll = true;
-                parent.rolls.push(...message.rolls);
+                
+                if (parent.rolls.length > 0) {
+                    parent.rolls.push(...message.rolls);
+                }
 
                 ChatUtility.updateChatMessage(parent, {
                     flags: parent.flags,


### PR DESCRIPTION
Fix an issue where vanilla rolls that were picked up to be added to an item card would sometimes add their rolls twice.