### PR TITLE
feature/end-concentration-button

### DIFF
--- a/css/ready-set-roll.css
+++ b/css/ready-set-roll.css
@@ -139,6 +139,11 @@
 	margin-left: 3px
 }
 
+.rsr-concentration-buttons {
+	margin-top: 3px;
+	line-height: 24px;
+}
+
 .rsr-indicator i:hover {
 	cursor: default;
 	text-shadow: none;

--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -113,6 +113,18 @@ export class ChatUtility {
         return message.flags.dnd5e?.roll?.type ?? (message.flags.dnd5e?.use ? ROLL_TYPE.ITEM : null);
     }
 
+    static getActorFromMessage(message) {
+        let actor = null;
+        if (message.speaker.token) {
+            const token = game.scenes.get(message.speaker.scene).tokens.get(message.speaker.token);
+            actor = token?.actor;
+        } else if (message.speaker.actor) {
+            actor = game.actors.get(message.speaker.actor);
+        }
+
+        return actor;
+    }
+
     static isMessageMultiRoll(message) {
         return (message.flags[MODULE_SHORT].advantage || message.flags[MODULE_SHORT].disadvantage || message.flags[MODULE_SHORT].dual
             || (message.rolls[0] instanceof CONFIG.Dice.D20Roll && message.rolls[0].options.advantageMode !== CONFIG.Dice.D20Roll.ADV_MODE.NORMAL)) ?? false;
@@ -207,6 +219,10 @@ function _setupCardListeners(message, html) {
             await _processApplyTotalButtonEvent(message, event);
         });
     }
+
+    html.find(`[data-action='rsr-${ROLL_TYPE.CONCENTRATION}']`).click(async event => {
+        await _processBreakConcentrationButtonEvent(message, event);
+    });
 }
 
 function _processVanillaMessage(message) {
@@ -308,6 +324,11 @@ async function _injectContent(message, type, html) {
             const render = await RenderUtility.render(TEMPLATE.MULTIROLL, { roll, key: type })
             html.find('.dice-total').replaceWith(render);
             html.find('.dice-tooltip').prepend(html.find('.dice-formula'));
+
+            if (message.flags[MODULE_SHORT].isConcentration)
+            {
+                await _injectBreakConcentrationButton(message, html)
+            }
             break;
         case ROLL_TYPE.ITEM:
             if (!message.isContentVisible) {
@@ -485,9 +506,24 @@ async function _injectDamageButton(message, html) {
     { 
         action: ROLL_TYPE.DAMAGE,
         ...button
-    })
+    });
 
     html.prepend($(render));
+}
+
+async function _injectBreakConcentrationButton(message, html) {
+    const button = {
+        title: CoreUtility.localize("DND5E.ConcentrationBreak"),
+        icon: "<i class=\"fas fa-xmark\"></i>"
+    }
+
+    const render = await RenderUtility.render(TEMPLATE.BUTTON, 
+    { 
+        action: ROLL_TYPE.CONCENTRATION,
+        ...button
+    });
+
+    html.append($(render).addClass('rsr-concentration-buttons'));
 }
 
 /**
@@ -590,6 +626,18 @@ async function _processDamageButtonEvent(message, event) {
     message.flags[MODULE_SHORT].renderDamage = true;  
 
     await ItemUtility.runItemAction(message, ROLL_TYPE.DAMAGE);
+}
+
+async function _processBreakConcentrationButtonEvent(message, event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const actor = ChatUtility.getActorFromMessage(message);
+
+    if (actor) {
+        const ActiveEffect5e = CONFIG.ActiveEffect.documentClass;
+        ActiveEffect5e._manageConcentration(event, actor);
+    }
 }
 
 /**

--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -128,18 +128,20 @@ export class ItemUtility {
         
         if (!card.flags[MODULE_SHORT].quickRoll) {
             return;
-        }
-
-        const item = await _ensureItemFromCard(card);    
+        }      
+          
+        const item = await _ensureItemFromCard(card);
         ItemUtility.ensureFlagsOnItem(item);
-
+        
         switch (action) {
             case ROLL_TYPE.DAMAGE:
                 const damageRolls = await ItemUtility.getDamageFromCard(card);
                 card.rolls.push(...damageRolls);
-                CoreUtility.playRollSound();
+                if (!game.dice3d || !game.dice3d.isEnabled()) {
+                    CoreUtility.playRollSound();
+                }                
                 break;
-        }
+        }  
 
         ChatUtility.updateChatMessage(card, { 
             flags: card.flags,
@@ -331,14 +333,7 @@ async function _ensureItemFromCard(card) {
 
     const itemId = card.flags.dnd5e.use.itemId;
     const storedData = card.getFlag("dnd5e", "itemData");
-
-    let actor = null;
-    if (card.speaker.token) {
-        const token = game.scenes.get(card.speaker.scene).tokens.get(card.speaker.token);
-        actor = token?.actor;
-    } else if (card.speaker.actor) {
-        actor = game.actors.get(card.speaker.actor);
-    }
+    const actor = ChatUtility.getActorFromMessage(card);
 
     return storedData && actor ? await Item5e.create(storedData, { parent: actor, temporary: true }) : actor?.items.get(itemId);
 }

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -18,7 +18,8 @@ export const ROLL_TYPE = {
     VERSATILE: "versatile",
     OTHER: "formula",
     ABILITY_CHECK: "abilityCheck",
-    TOOL_CHECK: "toolCheck"
+    TOOL_CHECK: "toolCheck",
+    CONCENTRATION: "concentration"
 }
 
 /**
@@ -56,9 +57,14 @@ export class RollUtility {
         config.advantage ||= advMode === CONFIG.Dice.D20Roll.ADV_MODE.ADVANTAGE;
         config.disadvantage ||= advMode === CONFIG.Dice.D20Roll.ADV_MODE.DISADVANTAGE;
 
+        if (config.isConcentration) {
+            config.flavor = `${CoreUtility.localize("DND5E.ToolPromptTitle", { tool: CoreUtility.localize("DND5E.Concentration") })}`;
+        }
+
         config.messageData[`flags.${MODULE_SHORT}`] = { 
             quickRoll: SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_VANILLA_ENABLED) || !ignore,
-            processed: true
+            processed: true,
+            isConcentration: config.isConcentration
         };
     }
 


### PR DESCRIPTION
Adds a button to concentration rolls that allows directly ending concentration. Uses the default concentration management prompt from dnd5e when there are multiple concentrations ongoing.