### PR TITLE
bugfix/properly-handle-vanilla-rolls

### DIFF
--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -295,11 +295,8 @@ async function _injectContent(message, type, html) {
                     await CoreUtility.waitUntil(() => !message._dice3danimating);
                 }
 
-                parent.flags[MODULE_SHORT].quickRoll = true;
-                
-                if (parent.rolls.length > 0) {
-                    parent.rolls.push(...message.rolls);
-                }
+                parent.flags[MODULE_SHORT].quickRoll = true;                
+                parent.rolls.push(...message.rolls);
 
                 ChatUtility.updateChatMessage(parent, {
                     flags: parent.flags,

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -83,7 +83,8 @@ export class RollUtility {
             quickRoll: !ignore,
             advantage: options.advantage,
             disadvantage: options.disadvantage,
-            altRoll: altRoll && !ignore
+            altRoll: altRoll && !ignore,
+            processed: ignore
         };
     }
 


### PR DESCRIPTION
Fixes an issue where vanilla item cards would ignore the results of their child cards in favour of rolling their own item actions when a child button was clicked.

Fixes #477.