### PR TITLE
bugfix/catch-parts-array

### DIFF
--- a/src/utils/item.js
+++ b/src/utils/item.js
@@ -106,7 +106,7 @@ export class ItemUtility {
 
         if (card.flags[MODULE_SHORT].renderDamage && item.hasDamage) {
             const damageRolls = await ItemUtility.getDamageFromCard(card);
-            card.rolls.push(...damageRolls);
+            card.rolls.push(...(Array.isArray(damageRolls) ? damageRolls : [ damageRolls ]));
         }
 
         card.flags[MODULE_SHORT].processed = true;


### PR DESCRIPTION
Fixes an issue where old parts-style damage arrays would break item card generation instead of being correctly handled.
