### PR TITLE
bugfix/damage-not-appearing

### DIFF
--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -103,7 +103,18 @@ export class HooksUtility {
                 RollUtility.processActorRoll(config);
                 return true;
             });
-        }
+        }        
+
+        // This needs to be outside if checks because it is also needed for vanilla rolls
+        // Should be removed in 4.1.0+ as this will be fixed internally by the system.
+        Hooks.on(HOOKS_DND5E.PRE_ROLL_DAMAGE, (rollConfig, dialogConfig, messageConfig) => {
+            if (!messageConfig.data.flags.dnd5e.originatingMessage) {
+                const messageId = rollConfig.event?.target.closest("[data-message-id]")?.dataset.messageId;
+                messageConfig.data.flags.dnd5e.originatingMessage = messageId;
+            }
+
+            return true;
+        });
 
         if (SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_ACTIVITY_ENABLED)) {
             Hooks.on(HOOKS_DND5E.PRE_USE_ACTIVITY, (activity, usageConfig, dialogConfig, messageConfig) => {              
@@ -127,20 +138,15 @@ export class HooksUtility {
                     roll.options.isCritical ??= rollConfig.isCritical;
                 }
 
-                if (!messageConfig.data.flags.dnd5e.originatingMessage) {
-                    const messageId = rollConfig.event?.target.closest("[data-message-id]")?.dataset.messageId;
-                    messageConfig.data.flags.dnd5e.originatingMessage = messageId;
-                }
-
                 return true;
-            })
+            });
 
             Hooks.on(HOOKS_DND5E.ACTIVITY_CONSUMPTION, (activity, usageConfig, messageConfig, updates) => {
                 if (activity.hasOwnProperty(ROLL_TYPE.ATTACK) && updates.item.length > 0 && messageConfig.data) {
                     messageConfig.data.flags[MODULE_SHORT].ammunition = updates.item[0]._id;
                     updates.item[0]["system.quantity"]++;
                 }
-            })
+            });
         }
     }
 


### PR DESCRIPTION
Fixes an issue where adding content to vanilla rolls would not appropriately add damage to the chat card if quick rolling activities is disabled.

Fixes #497.