### PR TITLE
Fix save activity without damage

### DIFF
--- a/src/utils/activity.js
+++ b/src/utils/activity.js
@@ -17,7 +17,7 @@ export class ActivityUtility {
         }
 
         const hasAttack = activity.hasOwnProperty(ROLL_TYPE.ATTACK);
-        const hasDamage = activity.hasOwnProperty(ROLL_TYPE.DAMAGE);
+        const hasDamage = activity.hasOwnProperty(ROLL_TYPE.DAMAGE) && activity[ROLL_TYPE.DAMAGE].parts.length > 0;;
         const hasHealing = activity.hasOwnProperty(ROLL_TYPE.HEALING);
 
         if (hasAttack) {            


### PR DESCRIPTION
When a saving throw activity has no damage, the damage property is still present but empty.

This will be a problem in line 50 when damage is spread.