### PR TITLE
bugfix/fix-target-value-checks

### DIFF
--- a/src/utils/render.js
+++ b/src/utils/render.js
@@ -56,9 +56,9 @@ async function _renderMultiRoll(data = {}) {
         }
 
         const critOptions = { 
-            critThreshold: roll.options.critical,
-            fumbleThreshold: roll.options.fumble,
-            targetValue: roll.options.targetValue - (bonusRoll?.total ?? 0),
+            critThreshold: roll.options.criticalSuccess,
+            fumbleThreshold: roll.options.criticalFailure,
+            target: roll.options.target - (bonusRoll?.total ?? 0),
             displayChallenge: roll.options.displayChallenge
         };
 
@@ -84,7 +84,7 @@ async function _renderMultiRoll(data = {}) {
 			ignored: tmpResults.some(r => r.discarded) ? true : undefined,
             critType: RollUtility.getCritTypeForDie(baseTerm, critOptions),
             d20Result: SettingsUtility.getSettingValue(SETTING_NAMES.D20_ICONS_ENABLED) ? d20Rolls.results[i].result : null,
-            dcResult: !critOptions.displayChallenge || isNaN(critOptions.targetValue) ? undefined : (total >= critOptions.targetValue ? "fas fa-check" : "fas fa-xmark")
+            dcResult: !critOptions.displayChallenge || isNaN(roll.options.target) ? undefined : (total >= roll.options.target ? "fas fa-check" : "fas fa-xmark")
 		});
     }
 

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -200,19 +200,19 @@ function _countCritsFumbles(die, options)
     let fumble = 0;
 
     if (die && die.faces > 1) {
-        let { critThreshold, fumbleThreshold, targetValue, ignoreDiscarded, displayChallenge } = options
+        let { critThreshold, fumbleThreshold, target, ignoreDiscarded, displayChallenge } = options
 
-        critThreshold = critThreshold ?? die.options.critical ?? die.faces;
-        fumbleThreshold = fumbleThreshold ?? die.options.fumble ?? 1;
+        critThreshold = critThreshold ?? die.options.criticalSuccess ?? die.faces;
+        fumbleThreshold = fumbleThreshold ?? die.options.criticalFailure ?? 1;
 
         for (const result of die.results) {
             if (result.rerolled || (result.discarded && ignoreDiscarded)) {
                 continue;
             }
 
-            if ((displayChallenge && result.result >= targetValue) || result.result >= critThreshold) {
+            if ((displayChallenge && result.result >= target) || result.result >= critThreshold) {
                 crit += 1;
-            } else if ((displayChallenge && result.result < targetValue) || result.result <= fumbleThreshold) {
+            } else if ((displayChallenge && result.result < target) || result.result <= fumbleThreshold) {
                 fumble += 1;
             }
         }


### PR DESCRIPTION
Fixes an issue where target values for rolls were being ignored due to a change in the data object that held that information.