### PR TITLE
bugfix/aa-compatibility

### DIFF
--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -1,4 +1,5 @@
 import { MODULE_SHORT, MODULE_TITLE } from "../module/const.js";
+import { MODULE_AA } from "../module/integration.js";
 import { ActivityUtility } from "./activity.js";
 import { ChatUtility } from "./chat.js";
 import { CoreUtility } from "./core.js";
@@ -104,7 +105,7 @@ export class HooksUtility {
             });
 
             Hooks.on(HOOKS_DND5E.POST_USE_ACTIVITY, (activity, usageConfig, results) => {
-                return false;
+                return CoreUtility.hasModule(MODULE_AA);
             });
 
             Hooks.on(HOOKS_DND5E.PRE_ROLL_ATTACK, (config, dialog, message) => {                


### PR DESCRIPTION
Fixes an issue where AA animations would not play if RSR is enabled. This "fix" causes an issue where certain activities will trigger subsequent actions that are not needed by RSR. Unfortunately, there is no easy way to avoid this while also allowing AA to work. As such, the hook is only allowed if AA is enabled.

Fixes #552.