### PR TITLE
hotfix/module-check-undefined

### DIFF
--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -81,7 +81,7 @@ export class CoreUtility {
      * @returns 
      */
     static hasModule(name) {
-        return game.modules.get(name)?.active;
+        return game.modules.get(name)?.active ?? false;
     }
 
     /**


### PR DESCRIPTION
Fixes an issue where popups would always trigger if AA does not exist in the module list.