### PR TITLE
bugfix/legendary-resistance-success

### DIFF
--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -328,6 +328,7 @@ async function _injectContent(message, type, html) {
 
             const roll = message.rolls[0];
             roll.options.displayChallenge = message.flags[MODULE_SHORT].displayChallenge;
+            roll.options.forceSuccess = message.flags.dnd5e?.roll?.forceSuccess;
 
             const render = await RenderUtility.render(TEMPLATE.MULTIROLL, { roll, key: type })
             html.find('.dice-total').replaceWith(render);

--- a/src/utils/render.js
+++ b/src/utils/render.js
@@ -59,7 +59,8 @@ async function _renderMultiRoll(data = {}) {
             critThreshold: roll.options.criticalSuccess,
             fumbleThreshold: roll.options.criticalFailure,
             target: roll.options.target - (bonusRoll?.total ?? 0),
-            displayChallenge: roll.options.displayChallenge
+            displayChallenge: roll.options.displayChallenge,
+            forceSuccess: roll.options.forceSuccess
         };
 
         // Die terms must have active results or the base roll total of the generated roll is 0.
@@ -84,7 +85,9 @@ async function _renderMultiRoll(data = {}) {
 			ignored: tmpResults.some(r => r.discarded) ? true : undefined,
             critType: RollUtility.getCritTypeForDie(baseTerm, critOptions),
             d20Result: SettingsUtility.getSettingValue(SETTING_NAMES.D20_ICONS_ENABLED) ? d20Rolls.results[i].result : null,
-            dcResult: !critOptions.displayChallenge || isNaN(roll.options.target) ? undefined : (total >= roll.options.target ? "fas fa-check" : "fas fa-xmark")
+            dcResult: !critOptions.displayChallenge || isNaN(roll.options.target) 
+                ? undefined 
+                : (roll.options.forceSuccess || total >= roll.options.target ? "fas fa-check" : "fas fa-xmark")
 		});
     }
 

--- a/src/utils/roll.js
+++ b/src/utils/roll.js
@@ -203,7 +203,11 @@ function _countCritsFumbles(die, options)
     let fumble = 0;
 
     if (die && die.faces > 1) {
-        let { critThreshold, fumbleThreshold, target, ignoreDiscarded, displayChallenge } = options
+        let { critThreshold, fumbleThreshold, target, ignoreDiscarded, displayChallenge, forceSuccess } = options
+
+        if (forceSuccess) {
+            return { crit: 1, fumble: 0 };
+        }
 
         critThreshold = critThreshold ?? die.options.criticalSuccess ?? die.faces;
         fumbleThreshold = fumbleThreshold ?? die.options.criticalFailure ?? 1;
@@ -212,7 +216,7 @@ function _countCritsFumbles(die, options)
             if (result.rerolled || (result.discarded && ignoreDiscarded)) {
                 continue;
             }
-
+            
             if ((displayChallenge && result.result >= target) || result.result >= critThreshold) {
                 crit += 1;
             } else if ((displayChallenge && result.result < target) || result.result <= fumbleThreshold) {


### PR DESCRIPTION
Fixes an issue where the success/failure display of a save would not correctly change to success when Legendary Resistance is used.

Fixes #578.