### PR TITLE
bugfix/chat-scrolling

### DIFF
--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -69,6 +69,8 @@ export class ChatUtility {
         const content = $(html).find('.message-content');
 
         if (content.length === 0) {
+            $(html).removeClass("rsr-hide");
+            ui.chat.scrollBottom();
             return;
         }
         


### PR DESCRIPTION
Adds an additional scroll bottom to an early out when message content is empty. Potentially fixes an issue where certain chat cards do not cause the chat window to scroll properly to bottom.

Potentially fixes #517.