### PR TITLE
feature/hide-npc-attack-result

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -19,6 +19,8 @@
             "aggregateDamage.hint": "When outputting a quick roll, combine all damage fields of the same type into a single field.",
             "enableD20Icons.name": "Show D20 Rolls for Quick Rolls",
             "enableD20Icons.hint": "When outputting a quick roll, display an icon showing the natural die roll next to the total result.",
+            "enableHideFinalResult.name": "Hide Result of NPC Attacks",
+            "enableHideFinalResult.hint": "When outputting a quick roll with an attack made by an actor that a player does not own, hide the final modified result of the roll so that only the result of the d20 is visible.",
             "enableDiceReroll.name": "Enable Dice Rerolling",
             "enableDiceReroll.hint": "When outputting a quick roll, enable the ability to click a specific die in the chat message tooltip to reroll that die in place.",
             "enableOverlayButtons.name": "Enable Overlay Buttons",
@@ -85,7 +87,8 @@
             "prompts": {
                 "retroCrit": "Upgrade to Crit?",
                 "retroAdv": "Roll {target}?"
-            }
+            },
+            "hide": "???"
         },
         "messages": {
             "error": {

--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -263,7 +263,7 @@ async function _enforceDualRolls(message) {
 
 async function _injectContent(message, type, html) {
     LogUtility.log("Injecting content into chat message");
-    const parent =message.getOriginatingMessage();
+    const parent = message.getOriginatingMessage();
     message.flags[MODULE_SHORT].displayChallenge = parent?.shouldDisplayChallenge ?? message.shouldDisplayChallenge;
     message.flags[MODULE_SHORT].displayAttackResult = game.user.isGM || (game.settings.get("dnd5e", "attackRollVisibility") !== "none");
 
@@ -395,12 +395,18 @@ async function _injectAttackRoll(message, html) {
     RollUtility.resetRollGetters(roll);
 
     roll.options.displayChallenge = message.flags[MODULE_SHORT].displayAttackResult;
+    roll.options.hideFinalAttack = SettingsUtility.getSettingValue(SETTING_NAMES.HIDE_FINAL_RESULT_ENABLED) && !game.actors.get(message.speaker.actor)?.isOwner;
 
     const render = await RenderUtility.render(TEMPLATE.MULTIROLL, { roll, key: ROLL_TYPE.ATTACK });
     const chatData = await roll.toMessage({}, { create: false });
     const rollHTML = (await new ChatMessage5e(chatData).getHTML()).find('.dice-roll');    
     rollHTML.find('.dice-total').replaceWith(render);
     rollHTML.find('.dice-tooltip').prepend(rollHTML.find('.dice-formula'));
+
+    if (roll.options.hideFinalAttack) {
+        rollHTML.find('.dice-tooltip').find('.tooltip-part.constant').remove();
+        rollHTML.find('.dice-formula').text("1d20 + " + CoreUtility.localize(`${MODULE_SHORT}.chat.hide`));
+    }    
 
     const ammo = message.getAssociatedActor().items.get(message.flags[MODULE_SHORT].ammunition)?.name;
 

--- a/src/utils/render.js
+++ b/src/utils/render.js
@@ -85,6 +85,7 @@ async function _renderMultiRoll(data = {}) {
 			ignored: tmpResults.some(r => r.discarded) ? true : undefined,
             critType: RollUtility.getCritTypeForDie(baseTerm, critOptions),
             d20Result: SettingsUtility.getSettingValue(SETTING_NAMES.D20_ICONS_ENABLED) ? d20Rolls.results[i].result : null,
+            hideAttack: roll.options.hideFinalAttack,
             dcResult: !critOptions.displayChallenge || isNaN(roll.options.target) 
                 ? undefined 
                 : (roll.options.forceSuccess || total >= roll.options.target ? "fas fa-check" : "fas fa-xmark")

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -14,6 +14,7 @@ export const SETTING_NAMES = {
     QUICK_VANILLA_ENABLED: "enableVanillaQuickRoll",
     ALWAYS_ROLL_MULTIROLL: "alwaysRollMulti",
     D20_ICONS_ENABLED: "enableD20Icons",
+    HIDE_FINAL_RESULT_ENABLED: "enableHideFinalResult",
     MANUAL_DAMAGE_MODE: "manualDamageMode",
     OVERLAY_BUTTONS_ENABLED: "enableOverlayButtons",
     DAMAGE_BUTTONS_ENABLED: "enableDamageButtons",
@@ -89,8 +90,9 @@ export class SettingsUtility {
 
         // CHAT CARD OPTIONS
         const chatCardOptions = [
-            { name: SETTING_NAMES.AGGREGATE_DAMAGE, default: false },           
+            { name: SETTING_NAMES.AGGREGATE_DAMAGE, default: false },
             { name: SETTING_NAMES.D20_ICONS_ENABLED, default: true },
+            { name: SETTING_NAMES.HIDE_FINAL_RESULT_ENABLED, default: false },
             //{ name: SETTING_NAMES.DICE_REROLL_ENABLED, default: true },
             { name: SETTING_NAMES.OVERLAY_BUTTONS_ENABLED, default: true },
             { name: SETTING_NAMES.DAMAGE_BUTTONS_ENABLED, default: true },

--- a/templates/rsr-multiroll.html
+++ b/templates/rsr-multiroll.html
@@ -1,7 +1,7 @@
 <div class="rsr-multiroll" data-key="{{key}}">
     {{#each entries}}
     <h4 class="dice-total {{#if this.ignored}}ignored{{/if}} {{this.critType}}">
-        {{this.total}}
+        {{#if this.hideAttack}}{{localize "rsr5e.chat.hide"}}{{else}}{{this.total}}{{/if}}
         {{#if this.d20Result}}<span class="die-icon {{this.critType}}">{{this.d20Result}}</span>{{/if}}
         {{#if this.dcResult}}<div class="icons"><i class="{{this.dcResult}}" inert=""></i></div>{{/if}}
     </h4>


### PR DESCRIPTION
Adds a setting that, when enabled, hides the final result of attacks from non-owned actors, showing only the d20 roll.

Fixes #426.