### PR TITLE
bugfix/vanilla-rolls-attack-mode

### DIFF
--- a/css/ready-set-roll.css
+++ b/css/ready-set-roll.css
@@ -46,16 +46,16 @@
 
 .rsr-supplement {
 	font-size: var(--font-size-11);
-    color: var(--color-text-dark-5);
+	color: var(--color-text-dark-5);
 	margin: 0.25rem 0 0;
 	text-align: center;
 }
 
 .rsr-supplement > strong {
 	color: var(--color-text-dark-primary);
-    text-transform: uppercase;
-    font-size: var(--font-size-10);
-    margin-right: 0.25rem;
+	text-transform: uppercase;
+	font-size: var(--font-size-10);
+	margin-right: 0.25rem;
 }
 
 .rsr-title {

--- a/css/ready-set-roll.css
+++ b/css/ready-set-roll.css
@@ -44,6 +44,20 @@
 	margin-bottom: 0.25rem;
 }
 
+.rsr-supplement {
+	font-size: var(--font-size-11);
+    color: var(--color-text-dark-5);
+	margin: 0.25rem 0 0;
+	text-align: center;
+}
+
+.rsr-supplement > strong {
+	color: var(--color-text-dark-primary);
+    text-transform: uppercase;
+    font-size: var(--font-size-10);
+    margin-right: 0.25rem;
+}
+
 .rsr-title {
 	font-family: var(--dnd5e-font-roboto);
 	font-weight: bold;


### PR DESCRIPTION
Fixes an issue where selecting an attack mode in a vanilla roll while RSR vanilla rolls is active would ignore the attack mode.

Fixes #593.