### PR TITLE
FoundryVTT v13 compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,11 +2,11 @@
 	"id": "ready-set-roll-5e",
 	"title": "Ready Set Roll for D&D5e",
 	"description": "This module overhauls rolls for the D&D 5e system with various quality of life improvements.",
-	"version": "3.4.9",
+	"version": "3.4.10",
 	"compatibility": {
-		"minimum": "12.324",
-		"verified": "12.331",
-		"maximum": "12"
+		"minimum": "13.341",
+		"verified": "13.344",
+		"maximum": "13"
 	},
 	"authors": [
 		{
@@ -45,8 +45,8 @@
 				"type": "system",
 				"manifest": "https://raw.githubusercontent.com/foundryvtt/dnd5e/master/system.json",
 				"compatibility": {
-					"minimum": "4.1.1",
-					"verified": "4.3.8"
+					"minimum": "5.0.0",
+					"verified": "5.0.3"
 				}
 			}
 		]

--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -419,7 +419,7 @@ async function _injectAttackRoll(message, html) {
 
     const render = await RenderUtility.render(TEMPLATE.MULTIROLL, { roll, key: ROLL_TYPE.ATTACK });
     const chatData = await roll.toMessage({}, { create: false });
-    const rollHTML = (await new ChatMessage5e(chatData).getHTML()).find('.dice-roll');    
+    const rollHTML = $(await new ChatMessage5e(chatData).renderHTML()).find('.dice-roll');
     rollHTML.find('.dice-total').replaceWith(render);
     rollHTML.find('.dice-tooltip').prepend(rollHTML.find('.dice-formula'));
 
@@ -449,7 +449,7 @@ async function _injectFormulaRoll(message, html) {
     if (!roll) return;
 
     const chatData = await roll.toMessage({}, { create: false });
-    const rollHTML = (await new ChatMessage5e(chatData).getHTML()).find('.dice-roll');
+    const rollHTML = $(await new ChatMessage5e(chatData).renderHTML()).find('.dice-roll');
     rollHTML.find('.dice-tooltip').prepend(rollHTML.find('.dice-formula'));
 
     const sectionHTML = $(await RenderUtility.render(TEMPLATE.SECTION,
@@ -471,7 +471,7 @@ async function _injectDamageRoll(message, html) {
     if (!rolls || rolls.length === 0) return;
 
     const chatData = await CONFIG.Dice.DamageRoll.toMessage(rolls, {}, { create: false });
-    const rollHTML = (await new ChatMessage5e(chatData).getHTML()).find('.dice-roll');
+    const rollHTML = $(await new ChatMessage5e(chatData).renderHTML()).find('.dice-roll');
     rollHTML.find('.dice-tooltip').prepend(rollHTML.find('.dice-formula'));
     rollHTML.find('.dice-result').addClass('rsr-damage');
 

--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -38,11 +38,11 @@ export class CoreUtility {
         const activeModifiers = {};
         const addModifiers = (key, pressed) => {
             activeModifiers[key] = pressed;
-            KeyboardManager.MODIFIER_CODES[key].forEach(n => activeModifiers[n] = pressed);
+            foundry.helpers.interaction.KeyboardManager.MODIFIER_CODES[key].forEach(n => activeModifiers[n] = pressed);
         };
-        addModifiers(KeyboardManager.MODIFIER_KEYS.CONTROL, event.ctrlKey || event.metaKey);
-        addModifiers(KeyboardManager.MODIFIER_KEYS.SHIFT, event.shiftKey);
-        addModifiers(KeyboardManager.MODIFIER_KEYS.ALT, event.altKey);
+        addModifiers(foundry.helpers.interaction.KeyboardManager.MODIFIER_KEYS.CONTROL, event.ctrlKey || event.metaKey);
+        addModifiers(foundry.helpers.interaction.KeyboardManager.MODIFIER_KEYS.SHIFT, event.shiftKey);
+        addModifiers(foundry.helpers.interaction.KeyboardManager.MODIFIER_KEYS.ALT, event.altKey);
         return game.keybindings.get("dnd5e", action).some(b => {
             if (game.keyboard.downKeys.has(b.key) && b.modifiers.every(m => activeModifiers[m])) return true;
             if (b.modifiers.length) return false;

--- a/src/utils/render.js
+++ b/src/utils/render.js
@@ -109,5 +109,5 @@ async function _renderDamageRoll(data = {}) {
  * @private
  */
 function _renderModuleTemplate(template, data) {
-    return renderTemplate(`modules/${MODULE_NAME}/templates/${template}`, data);
+    return foundry.applications.handlebars.renderTemplate(`modules/${MODULE_NAME}/templates/${template}`, data);
 }


### PR DESCRIPTION
Hi!
I am no developer so not sure if my changes are any good, my first contribution to a project too, hope i did everything right 😅

I changed some function marked as becoming deprecated from foundry.

getHTML should be replaced by renderHTML
Problem beeing that renderHTML returns an HTMLElement, wich brakes the .find function. I "fixed" it by converting the HTMLElement back to a jquery. Not sure if that's the way to go, but was the simples solution without rewriting everything.

Tested it and rolling seem to work just fine. 