### PR TITLE
Update to V14 / D&D5e 5.3.0 Compatibility + New Features (v5.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,31 +49,49 @@ The following modules have been verified as compatible from the specified module
 
 ![retroactiveoverlay](https://github.com/MangoFVTT/fvtt-ready-set-roll-5e/assets/110994627/d73efc5b-cf47-4dca-a5af-6dff9c531359)
 
-<!-- ### Individual Dice Rerolling - TEMPORARILY DISABLED IN 3.0+
-- If enabled via the module settings, individual dice rolls in quick rolls can be rerolled by clicking on that individual dice within the chat card.
-- Rerolling dice will automatically live edit the quick roll's chat card, displaying the new rolls and roll totals alongside the already existing dice.
+### Retroactive Bonus Manager
+- **Post-Roll Bonuses**: You can seamlessly add bonuses (like Bardic Inspiration, Bless, or custom numeric values) to a roll *after* it has already been made in chat.
+- **Smart Detection**: Injects a Plus (+) icon into Attack, Damage, Ability Check, Skill, and Saving Throw headers. Clicking this opens a custom dialog to select detected active effects on your actor, or input custom formulas.
+- **Consumption Logic**: Supports "Once" effects and can automatically consume item uses (e.g., ticking down a Bardic Inspiration die) when a bonus is applied.
 
-![dicereroll](https://github.com/MangoFVTT/fvtt-ready-set-roll-5e/assets/110994627/d0c16a57-e41e-49df-b88f-464b152d1658) -->
+#### How to Configure Retroactive Bonuses
+The Bonus Manager automatically detects **Active Effects** on your actor that are configured to provide a retroactive bonus. To create a compatible effect, add a change to an Active Effect with the following details:
+
+* **Attribute Key**: `flags.rsr5e-addon.bonus`
+* **Value Syntax**: `formula; type: [types]; [options]`
+
+**Syntax Breakdown**
+* **Formula**: The bonus to add (e.g., `1d4`, `+5`, or `@abilities.cha.mod`).
+* **type**: (Optional) Restrict where the bonus appears. Use `attack`, `damage`, `check`, `save`, `skill`, or `any` (default). You can list multiple separated by commas.
+* **once**: (Optional) If included, the Active Effect is deleted automatically after the bonus is used once.
+* **consume**: (Optional) Consumes a usage from an item.
+    * `consume: origin` — Consumes 1 use from the item that created the effect.
+    * `consume: [Item Name or ID]` — Consumes 1 use from a specific named item on the actor.
+
+**Examples**
+1. **Bless**: `1d4; type: attack, save`
+2. **Bardic Inspiration**: `1d8; type: attack, save, check, skill; once`
+3. **Static Tactical Bonus**: `+2; type: attack`
+
+#### How to Use in Play
+1. Perform your roll as usual using Ready Set Roll.
+2. In the Chat Card, look for the **Plus (+)** icon in the header of the roll section.
+3. Click the icon to open the **Bonus Selector**.
+4. Select one of your detected Active Effects or choose **Custom Bonus** to type in a formula.
+5. Click **Apply Bonus** to update the roll result in place.
+
+<img width="1199" height="624" alt="image" src="https://github.com/user-attachments/assets/9a53d49b-6163-43bd-a974-a282d3c0a360" />
+
+### Individual Dice Rerolling & GM Fudging
+- **Interactive Dice**: If enabled via the module settings, players can individually reroll specific dice by simply left-clicking on the die result within the chat card tooltip.
+- **GM Fudging**: GMs have the added ability to silently control fate. By right-clicking any die result within a tooltip, the GM can manually input and set it to a specific number.
+- Modifying dice will automatically recalculate the modifiers, update the totals, and live-edit the chat card to display the new results seamlessly.
 
 ### Apply Individual Damage
 - If enabled via the module settings, each damage field in a quick roll chat card can apply damage or healing to selected or targeted tokens via overlay buttons. This extends core system behaviour (applying damage via context menus) to allow for the application of each damage field individually instead of as a single whole.
 - Damage fields can be applied in a specific manner (damage or healing) regardless of the actual damage type. This is intended to allow Players or GMs to manually decide what to do with the damage field in the event of edge cases (such as a specific damage type healing instead of doing damage for a particular creature).
 
 ![damageoverlay](https://github.com/MangoFVTT/fvtt-ready-set-roll-5e/assets/110994627/f610f9be-9578-435a-abb5-bac082abe06f)
-
-<!-- ### Macro Support - TEMPORARILY DISABLED IN 3.0+
-- Module-specific macros can be called to directly create quick rolls with custom options, or to output a set of damage rolls without any attached item.
-- Macros are available in the following format:
-    - `rsr5e.macro.rollItem('item ID or name', 'actor ID or name (optional)', options = {})`
-    - `rsr5e.macro.rollDamage([['formula 1', 'damage type 1'], ['formula 2', 'damage type 2'], ...], options = {})`
-
-![macros](https://user-images.githubusercontent.com/110994627/214150998-869afaaa-b93a-4ff0-b9af-470c54f35d52.png)
-
-### String Queries - TEMPORARILY DISABLED IN 3.0+
-- Macro scripts can call `rsr5e.query()` on a Roll20 style query (e.g. `'?{Select Die Value|1d4,4|1d6,6|1d8,8}'`. 
-- This will bring up a dialog prompt parsed from that query when the macro is executed, and return the selected value for later use.
-
-![image](https://user-images.githubusercontent.com/110994627/214161613-1bb4720e-b0b4-4f85-9658-e8c44d1227c3.png) -->
 
 ## Planned Features
 - [See [FEATURE] Issues List](https://github.com/MangoFVTT/fvtt-ready-set-roll-5e/issues?q=is%3Aopen+is%3Aissue+label%3Afeature)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Ready Set Roll** is a Foundry VTT module that accelerates the built in rolling system of the [Foundry DnD5e system](https://github.com/foundryvtt/dnd5e). It allows for quick rolls with advantage, disadadvantage, and other modifiers for skills, items, ability checks, and saving throws. This module is a complete rewrite and modernisation of [RedReign](https://github.com/RedReign)'s [Better Rolls for 5e](https://github.com/RedReign/FoundryVTT-BetterRolls5e) module, which is no longer supported, and no longer functional as of more recent versions of FoundryVTT. 
 
-If you are feeling generous, and would like to support my work, you can do so through this [Paypal](https://www.paypal.com/paypalme/MangoFVTT) link, or through the sponsorship options in the sidebar. Thank you!
+If you are feeling generous, and would like to support my work (MangoFYTT), you can do so through this [Paypal](https://www.paypal.com/paypalme/MangoFVTT) link, or through the sponsorship options in the sidebar. Thank you!
 
 ## Installation
 

--- a/css/ready-set-roll.css
+++ b/css/ready-set-roll.css
@@ -255,7 +255,7 @@
    ========================================== */
 
 /* Reroll Styling - Target the structure directly */
-.dice-tooltip .dice-rolls .roll.die {
+.dice-tooltip .dice-rolls .roll {
     cursor: pointer !important; /* Changed from context-menu to pointer for better UX */
     transition: all 0.2s;
     position: relative;
@@ -263,7 +263,7 @@
     pointer-events: auto !important; 
 }
 
-.dice-tooltip .dice-rolls .roll.die:hover {
+.dice-tooltip .dice-rolls .roll:hover {
     text-shadow: 0 0 5px red; /* Updated to match your JS injection style */
     transform: scale(1.2);    /* Updated scale to match your JS injection */
     color: white;             /* Updated color to match your JS injection */
@@ -271,7 +271,7 @@
     font-weight: bold;
 }
 
-.dice-tooltip .dice-rolls .roll.die.rsr-ready {
+.dice-tooltip .dice-rolls .roll.rsr-ready {
     /* Marker class to ensure styles apply if needed specifically */
 }
 

--- a/css/ready-set-roll.css
+++ b/css/ready-set-roll.css
@@ -249,3 +249,52 @@
 .rsr-hide {
     display: none !important;
 }
+
+/* ==========================================
+   ADDON STYLES (Reroll, Bonuses, Splitting)
+   ========================================== */
+
+/* Reroll Styling - Target the structure directly */
+.dice-tooltip .dice-rolls .roll.die {
+    cursor: pointer !important; /* Changed from context-menu to pointer for better UX */
+    transition: all 0.2s;
+    position: relative;
+    /* CRITICAL FIX: Forces the die to receive mouse clicks */
+    pointer-events: auto !important; 
+}
+
+.dice-tooltip .dice-rolls .roll.die:hover {
+    text-shadow: 0 0 5px red; /* Updated to match your JS injection style */
+    transform: scale(1.2);    /* Updated scale to match your JS injection */
+    color: white;             /* Updated color to match your JS injection */
+    z-index: 100;
+    font-weight: bold;
+}
+
+.dice-tooltip .dice-rolls .roll.die.rsr-ready {
+    /* Marker class to ensure styles apply if needed specifically */
+}
+
+/* Retroactive Bonus Button in Headers */
+.rsr-addon-bonus-btn {
+    display: inline-block;
+    margin-left: 8px; /* Standardized margin */
+    cursor: pointer;
+    font-size: 0.9em; /* Matching JS injection */
+    opacity: 0.6;     /* Matching JS injection */
+    transition: opacity 0.2s;
+}
+
+.rsr-addon-bonus-btn:hover {
+    opacity: 1;
+    color: var(--color-text-hyperlink, #ff6400); /* Fallback color added */
+    text-shadow: 0 0 8px var(--color-shadow-highlight, #ff0000);
+}
+
+/* Application V2 Window Styles */
+.rsr-bonus-window .form-group {
+    transition: background 0.2s;
+}
+.rsr-bonus-window .form-group:hover {
+    background: var(--color-bg-light-2) !important;
+}

--- a/css/ready-set-roll.css
+++ b/css/ready-set-roll.css
@@ -298,3 +298,15 @@
 .rsr-bonus-window .form-group:hover {
     background: var(--color-bg-light-2) !important;
 }
+/* Ensure RSR titles have enough space for the addon buttons */
+.rsr-title {
+    position: relative;
+    padding-right: 25px; /* Creates a gutter for the button */
+}
+
+.rsr-addon-bonus-btn {
+    position: absolute;
+    right: 5px;
+    top: 50%;
+    transform: translateY(-50%);
+}

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
 	"id": "ready-set-roll-5e",
 	"title": "Ready Set Roll for D&D5e",
 	"description": "This module overhauls rolls for the D&D 5e system with various quality of life improvements.",
-	"version": "3.5.0",
+	"version": "4.0.0",
 	"compatibility": {
 		"minimum": "13.341",
 		"verified": "13.345",
@@ -12,6 +12,10 @@
 		{
 			"name": "MangoFVTT",
 			"discord": "MangoFVTT"
+		},
+		{
+			"name": "Max Bremer",
+			"role": "Contributor"
 		}
 	],
 	"esmodules": [
@@ -52,8 +56,8 @@
 		]
 	},
 	"url": "https://github.com/MangoFVTT/fvtt-ready-set-roll-5e",
-	"manifest": "https://raw.githubusercontent.com/MangoFVTT/fvtt-ready-set-roll-5e/master/module.json",
-	"download": "https://github.com/MangoFVTT/fvtt-ready-set-roll-5e/releases/download/release-3.5.0/rsr5e-release-3.5.0.zip",
+	"manifest": "https://github.com/maxobremer/fvtt-ready-set-roll-5e/releases/latest/download/module.json",
+  "download": "https://github.com/maxobremer/fvtt-ready-set-roll-5e/releases/download/v4.0.0/module.zip",
 	"bugs": "https://github.com/MangoFVTT/fvtt-ready-set-roll-5e/issues",
 	"readme": "https://github.com/MangoFVTT/fvtt-ready-set-roll-5e/blob/master/README.md"
 }

--- a/src/utils/activity.js
+++ b/src/utils/activity.js
@@ -5,179 +5,346 @@ import { CoreUtility } from "./core.js";
 import { ROLL_TYPE } from "./roll.js";
 import { SETTING_NAMES, SettingsUtility } from "./settings.js";
 
-/**
- * Utility class to handle quick rolling functionality for activities.
- */
 export class ActivityUtility {
-    static setRenderFlags(activity, message) {
-        if (!message.data.flags || !message.data.flags[MODULE_SHORT]) {
-            return;
+
+    /**
+     * Resolve the activity associated with a chat message.
+     *
+     * dnd5e 5.3.0: `getAssociatedActivity()` is now a native ChatMessage5e method
+     * (line 69694 of dnd5e.mjs). It tries `fromUuidSync(flags.dnd5e.activity.uuid)`
+     * first, then falls back to `getAssociatedItem()?.system.activities?.get(flags.dnd5e.activity.id)`.
+     * We call it directly and only fall through to manual UUID/id resolution when the
+     * message object is a plain data object (e.g. during preCreateChatMessage before the
+     * document is instantiated) where the method may not exist.
+     *
+     * NOTE: `message.system.activity` is intentionally NOT used as a primary path.
+     * In 5.3.0 it is a getter on UsageMessageData that itself calls
+     * `this.parent.getAssociatedActivity()` — identical to calling the method directly,
+     * but with the added risk of throwing when `message.system` is undefined (non-usage
+     * messages) or when the system data model is not yet initialised (preCreate hooks).
+     */
+    static _getActivityFromMessage(message) {
+        // Primary: native ChatMessage5e method available on instantiated documents.
+        if (typeof message.getAssociatedActivity === "function") {
+            const act = message.getAssociatedActivity();
+            if (act) return act;
         }
-        
-        if (!message.data.flags[MODULE_SHORT].quickRoll) {
-            return;
-        }        
 
-        const hasAttack = activity.hasOwnProperty(ROLL_TYPE.ATTACK);
-        const hasDamage = activity.hasOwnProperty(ROLL_TYPE.DAMAGE);
-        const hasHealing = activity.hasOwnProperty(ROLL_TYPE.HEALING);
-        const hasFormula = activity.hasOwnProperty(ROLL_TYPE.FORMULA);
+        // Fallback A: resolve via item UUID + activity id (covers preCreate where the
+        // document method above may not yet exist, or may return null because flags
+        // haven't been saved to the database yet and fromUuidSync can't find the UUID).
+        let item = null;
+        if (typeof message.getAssociatedItem === "function") item = message.getAssociatedItem();
+        if (!item && message.flags?.dnd5e?.item?.uuid) item = fromUuidSync(message.flags.dnd5e.item.uuid, { strict: false });
+        if (!item && message.flags?.dnd5e?.use?.itemUuid) item = fromUuidSync(message.flags.dnd5e.use.itemUuid, { strict: false });
 
-        if (hasAttack) {            
-            message.data.flags[MODULE_SHORT].renderAttack = true;
+        const activityId = message.flags?.dnd5e?.activity?.id;
+        if (item && activityId) {
+            const act = item.system?.activities?.get(activityId);
+            if (act) return act;
+        }
+
+        // Fallback B: resolve directly via activity UUID stored in flags.
+        // dnd5e 5.3.0: the activity UUID is stored at flags.dnd5e.activity.uuid
+        // (set by Activity#messageFlags getter, line 16711 of dnd5e.mjs).
+        const activityUuid = message.flags?.dnd5e?.activity?.uuid;
+        if (activityUuid) {
+            const act = fromUuidSync(activityUuid, { strict: false });
+            if (act) return act;
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve the actor associated with a chat message.
+     *
+     * dnd5e 5.3.0: delegates to ChatUtility.getActorFromMessage which already uses the
+     * native getAssociatedActor() method with a proper null-safe manual fallback.
+     */
+    static _getActorFromMessage(message) {
+        return ChatUtility.getActorFromMessage(message);
+    }
+
+    /**
+     * Extract Roll instances from the raw return value of rollAttack / rollDamage /
+     * rollFormula. In dnd5e 5.3.0 all three methods return Roll[] directly when
+     * messageConfig.create is false, so the array branch is hit in the normal case.
+     * The other branches are kept for defensive compatibility.
+     */
+    static _extractRolls(result) {
+        let extracted = [];
+        if (!result) return extracted;
+        const items = Array.isArray(result) ? result : [result];
+        for (const item of items) {
+            if (!item) continue;
+            if (item instanceof Roll) {
+                extracted.push(item);
+            } else if (item.rolls && Array.isArray(item.rolls)) {
+                extracted.push(...item.rolls);
+            } else if (item.roll && item.roll instanceof Roll) {
+                extracted.push(item.roll);
+            } else if (item.class && item.formula) {
+                try { extracted.push(Roll.fromData(item)); } catch(e) {}
+            }
+        }
+        return extracted;
+    }
+
+    /**
+     * Set RSR render flags on the message based on the activity's capabilities.
+     * Called from processChatMessage when flags haven't been written yet (i.e. the
+     * message was not caught by preCreateChatMessage, which can happen when another
+     * module creates a usage message programmatically after the fact).
+     */
+    static setRenderFlags(activity, message) {
+        if (!message || !activity) return;
+        const flags = message.flags;
+        if (!flags || !flags[MODULE_SHORT] || !flags[MODULE_SHORT].quickRoll) return;
+
+        const hasAttack  = activity.type === "attack"  || !!activity.attack   || activity.hasOwnProperty(ROLL_TYPE.ATTACK);
+        const hasDamage  = activity.type === "damage"  || !!activity.damage   || activity.type === "attack" || activity.type === "save" || activity.hasOwnProperty(ROLL_TYPE.DAMAGE);
+        const hasHealing = activity.type === "heal"    || !!activity.healing  || activity.hasOwnProperty(ROLL_TYPE.HEALING);
+        const hasFormula = activity.type === "utility" || !!activity.roll     || activity.hasOwnProperty(ROLL_TYPE.FORMULA);
+
+        if (hasAttack) {
+            flags[MODULE_SHORT].renderAttack = true;
         }
 
         const manualDamageMode = SettingsUtility.getSettingValue(SETTING_NAMES.MANUAL_DAMAGE_MODE);
 
-        if (hasDamage && activity[ROLL_TYPE.DAMAGE]?.parts?.length > 0) {            
-            message.data.flags[MODULE_SHORT].manualDamage = (manualDamageMode === 2 || (manualDamageMode === 1 && hasAttack));
-            message.data.flags[MODULE_SHORT].renderDamage = !message.data.flags[MODULE_SHORT].manualDamage;
+        if (hasDamage) {
+            flags[MODULE_SHORT].manualDamage = (manualDamageMode === 2 || (manualDamageMode === 1 && hasAttack));
+            flags[MODULE_SHORT].renderDamage = !flags[MODULE_SHORT].manualDamage;
         }
 
         if (hasHealing) {
-            message.data.flags[MODULE_SHORT].isHealing = true;
-            message.data.flags[MODULE_SHORT].renderDamage = true; 
+            flags[MODULE_SHORT].isHealing = true;
+            flags[MODULE_SHORT].renderDamage = true;
         }
 
-        if (hasFormula && activity[ROLL_TYPE.FORMULA]?.formula !== '') {
-            message.data.flags[MODULE_SHORT].renderFormula = true;
-
-            if (activity.roll?.name && activity.roll.name !== "") {
-                message.data.flags[MODULE_SHORT].formulaName = activity.roll?.name;
+        if (hasFormula) {
+            flags[MODULE_SHORT].renderFormula = true;
+            const fName = activity.roll?.name || activity[ROLL_TYPE.FORMULA]?.name;
+            if (fName && fName !== "") {
+                flags[MODULE_SHORT].formulaName = fName;
             }
         }
     }
 
+    /**
+     * Execute all pending roll actions for a usage message (attack, damage, formula)
+     * and persist the resulting rolls back to the message flags.
+     */
     static async runActivityActions(message) {
-        if (message.flags[MODULE_SHORT].renderAttack) {
-            const attackRolls = await ActivityUtility.getAttackFromMessage(message);
-            _injectRollsToMessage(message, attackRolls, CONFIG.Dice.D20Roll);
+        let currentRolls = Array.from(message.flags[MODULE_SHORT]?.rolls || []);
 
-            message.flags[MODULE_SHORT].isCritical = message.flags[MODULE_SHORT].dual ? false : attackRolls[0].isCritical
+        if (message.flags[MODULE_SHORT].renderAttack) {
+            const rawAttack = await ActivityUtility.getAttackFromMessage(message);
+            const attackRolls = ActivityUtility._extractRolls(rawAttack);
+
+            if (attackRolls.length > 0) {
+                currentRolls = _injectRollsToArray(currentRolls, attackRolls, CONFIG.Dice.D20Roll);
+                // dual flag means a multi-roll was enforced by ALWAYS_ROLL_MULTIROLL;
+                // in that case isCritical is determined later during rendering.
+                message.flags[MODULE_SHORT].isCritical = message.flags[MODULE_SHORT].dual
+                    ? false
+                    : attackRolls[0].isCritical;
+            } else {
+                message.flags[MODULE_SHORT].isCritical = false;
+            }
         }
 
         if (message.flags[MODULE_SHORT].renderDamage) {
-            const damageRolls = await ActivityUtility.getDamageFromMessage(message);
-            _injectRollsToMessage(message, damageRolls, CONFIG.Dice.DamageRoll);
+            const rawDamage = await ActivityUtility.getDamageFromMessage(message);
+            const damageRolls = ActivityUtility._extractRolls(rawDamage);
+
+            if (damageRolls.length > 0) {
+                currentRolls = _injectRollsToArray(currentRolls, damageRolls, CONFIG.Dice.DamageRoll);
+            }
         }
 
         if (message.flags[MODULE_SHORT].renderFormula) {
-            const formulaRolls = await ActivityUtility.getFormulaFromMessage(message);
-            _injectRollsToMessage(message, formulaRolls, CONFIG.Dice.BasicRoll);
+            const rawFormula = await ActivityUtility.getFormulaFromMessage(message);
+            const formulaRolls = ActivityUtility._extractRolls(rawFormula);
+
+            if (formulaRolls.length > 0) {
+                currentRolls = _injectRollsToArray(currentRolls, formulaRolls, CONFIG.Dice.BasicRoll);
+            }
         }
 
         message.flags[MODULE_SHORT].processed = true;
+        message.flags[MODULE_SHORT].rolls = currentRolls.map(r => r.toJSON ? r.toJSON() : r);
 
-        ChatUtility.updateChatMessage(message, { 
-            flags: message.flags,
-            rolls: message.rolls,
+        await ChatUtility.updateChatMessage(message, {
+            flags: message.flags
         });
-    }    
+    }
 
-    static async runActivityAction(message, action) {        
+    /**
+     * Execute a single on-demand roll action (currently only ROLL_TYPE.DAMAGE, triggered
+     * by the manual damage button) and persist the result.
+     */
+    static async runActivityAction(message, action) {
+        let currentRolls = Array.from(message.flags[MODULE_SHORT]?.rolls || []);
+
         switch (action) {
-            case ROLL_TYPE.DAMAGE:
-                const damageRolls = await ActivityUtility.getDamageFromMessage(message);
-                _injectRollsToMessage(message, damageRolls, CONFIG.Dice.DamageRoll);
-                break;
-        }  
+            case ROLL_TYPE.DAMAGE: {
+                const rawDamage = await ActivityUtility.getDamageFromMessage(message);
+                const damageRolls = ActivityUtility._extractRolls(rawDamage);
 
-        ChatUtility.updateChatMessage(message, { 
-            flags: message.flags,
-            rolls: message.rolls
+                if (damageRolls.length > 0) {
+                    currentRolls = _injectRollsToArray(currentRolls, damageRolls, CONFIG.Dice.DamageRoll);
+                }
+                break;
+            }
+        }
+
+        message.flags[MODULE_SHORT].rolls = currentRolls.map(r => r.toJSON ? r.toJSON() : r);
+
+        await ChatUtility.updateChatMessage(message, {
+            flags: message.flags
         });
     }
 
+    /**
+     * Roll the attack for the activity associated with this message.
+     *
+     * dnd5e 5.3.0: rollAttack() merges our config object into its own rollConfig via
+     * foundry.utils.mergeObject, then passes config.advantage / config.disadvantage
+     * into D20Roll.applyKeybindings() (line 78549), which sets roll.options.advantageMode.
+     * Passing them at the top level of the config object is therefore the correct approach.
+     *
+     * The ammunition field passed here is the item ID stored during the
+     * activityConsumption hook. rollAttack() looks up the ammo item internally when
+     * needed; passing the ID in config means it reaches roll.options.ammunition for
+     * the PRE_ROLL_ATTACK hook to see.
+     */
     static getAttackFromMessage(message) {
-        const activity = message.getAssociatedActivity();
+        const activity = ActivityUtility._getActivityFromMessage(message);
+        if (!activity || typeof activity.rollAttack !== "function") return null;
 
-        const usageConfig = { 
-            advantage: message.flags[MODULE_SHORT].advantage ?? false,
-            disadvantage: message.flags[MODULE_SHORT].disadvantage ?? false,            
-            ammunition: message.flags[MODULE_SHORT].ammunition
-        }
+        const config = {
+            advantage:    message.flags[MODULE_SHORT].advantage    ?? false,
+            disadvantage: message.flags[MODULE_SHORT].disadvantage ?? false,
+            ammunition:   message.flags[MODULE_SHORT].ammunition
+        };
 
-        const dialogConfig = {
-            configure: false
-        }
+        const dialogConfig  = { configure: false };
+        const messageConfig = { create: false, data: { flags: {} }, flags: {} };
+        messageConfig.data.flags[MODULE_SHORT] = { quickRoll: true };
+        messageConfig.flags[MODULE_SHORT]      = { quickRoll: true };
 
-        const messageConfig = {
-            create: false,
-            data: {
-                flags: {}
-            }
-        }
-
-        messageConfig.data.flags[MODULE_SHORT] = {
-            quickRoll: true
-        }
-
-        return activity.rollAttack(usageConfig, dialogConfig, messageConfig);
+        return activity.rollAttack(config, dialogConfig, messageConfig);
     }
 
+    /**
+     * Roll damage for the activity associated with this message.
+     *
+     * dnd5e 5.3.0: scaling is stored in message.system.scaling (a NumberField on
+     * UsageMessageData, written at line 17085 of dnd5e.mjs). The legacy path
+     * message.flags?.dnd5e?.scaling is kept as a fallback for older persisted messages.
+     *
+     * Scaling is applied two ways:
+     *   1. usageConfig.scaling   → used by getDamageConfig → _processDamagePart via
+     *                              `rollConfig.scaling ?? rollData.scaling` (line 12494).
+     *   2. activity.item.flags.dnd5e.scaling → populates rollData.scaling through
+     *                              getRollData() on the item clone, which is the path
+     *                              `rollData.scaling` in _processDamagePart falls back to.
+     *
+     * Both paths remain necessary: (1) is authoritative when the activity is called
+     * outside a full use() workflow (as RSR does), and (2) ensures the item's own
+     * formula variables resolve correctly for cantrips and other scaling modes that
+     * read rollData rather than rollConfig.
+     *
+     * midiOptions is not part of the dnd5e 5.3.0 API but is read by midi-qol from the
+     * config object when that module is active; it is left in place.
+     */
     static getDamageFromMessage(message) {
-        const activity = message.getAssociatedActivity();
-        const actor = message.getAssociatedActor();
-    
+        const activity = ActivityUtility._getActivityFromMessage(message);
+        const actor    = ActivityUtility._getActorFromMessage(message);
+
+        if (!activity || !actor || typeof activity.rollDamage !== "function") return null;
+
+        // Resolve scaling from system data (5.3.0 canonical) with flags fallback.
+        const scaling = message.system?.scaling ?? message.flags?.dnd5e?.scaling ?? 0;
+
+        // Stamp scaling onto the item clone so rollData.scaling is populated correctly
+        // for formula resolution (see getDamageConfig → getRollData path).
         activity.item.flags.dnd5e ??= {};
-        activity.item.flags.dnd5e.scaling = message.flags.dnd5e.scaling;
+        if (activity.item.flags.dnd5e.scaling !== scaling) {
+            activity.item.flags.dnd5e.scaling = scaling;
+        }
 
-        const usageConfig = {
+        const config = {
             isCritical: message.flags[MODULE_SHORT].isCritical ?? false,
-            ammunition: actor.items.get(message.flags[MODULE_SHORT].ammunition),
-            scaling: message.flags.dnd5e.scaling,
-            midiOptions: CoreUtility.hasModule(MODULE_MIDI) ? { isCritical: message.flags[MODULE_SHORT].isCritical ?? false } : undefined
-        }
+            // Pass the live Item document so rollDamage can read ammo properties.
+            ammunition: actor.items?.get(message.flags[MODULE_SHORT].ammunition),
+            scaling,
+            midiOptions: CoreUtility.hasModule(MODULE_MIDI)
+                ? { isCritical: message.flags[MODULE_SHORT].isCritical ?? false }
+                : undefined
+        };
 
-        const dialogConfig = { 
-            configure: false 
-        }
+        const dialogConfig  = { configure: false };
+        const messageConfig = { create: false, data: { flags: {} }, flags: {} };
+        messageConfig.data.flags[MODULE_SHORT] = { quickRoll: true };
+        messageConfig.flags[MODULE_SHORT]      = { quickRoll: true };
 
-        const messageConfig = {
-            create: false,
-            data: {
-                flags: {}
-            }
-        }
-
-        messageConfig.data.flags[MODULE_SHORT] = {
-            quickRoll: true
-        }
-    
-        return activity.rollDamage(usageConfig, dialogConfig, messageConfig);
+        return activity.rollDamage(config, dialogConfig, messageConfig);
     }
 
+    /**
+     * Roll the utility formula for the activity associated with this message.
+     *
+     * dnd5e 5.3.0: UtilityActivity.rollFormula() uses rollConfig.scaling (passed via
+     * getRollData / scaledFormula) but does not explicitly consume a scaling field from
+     * config the way rollDamage does. Passing it anyway is harmless and future-proof.
+     */
     static getFormulaFromMessage(message) {
-        const activity = message.getAssociatedActivity();
+        const activity = ActivityUtility._getActivityFromMessage(message);
+        if (!activity || typeof activity.rollFormula !== "function") return null;
+
+        const scaling = message.system?.scaling ?? message.flags?.dnd5e?.scaling ?? 0;
 
         activity.item.flags.dnd5e ??= {};
-        activity.item.flags.dnd5e.scaling = message.flags.dnd5e.scaling;
-
-        const usageConfig = {
-            scaling: message.flags.dnd5e.scaling
+        if (activity.item.flags.dnd5e.scaling !== scaling) {
+            activity.item.flags.dnd5e.scaling = scaling;
         }
 
-        const dialogConfig = {
-            configure: false
-        }
+        const config        = { scaling };
+        const dialogConfig  = { configure: false };
+        const messageConfig = { create: false, data: { flags: {} }, flags: {} };
+        messageConfig.data.flags[MODULE_SHORT] = { quickRoll: true };
+        messageConfig.flags[MODULE_SHORT]      = { quickRoll: true };
 
-        const messageConfig = {
-            create: false
-        }
-
-        return activity.rollFormula(usageConfig, dialogConfig, messageConfig);
+        return activity.rollFormula(config, dialogConfig, messageConfig);
     }
 }
 
-function _injectRollsToMessage(message, rolls, cleanType)
-{
-    if (!message || !CoreUtility.isIterable(rolls)) {
-        return;
+/**
+ * Merge a set of new rolls into an existing roll array, first removing any rolls of the
+ * same class so that re-rolls replace rather than duplicate the previous result.
+ *
+ * @param {Roll[]|object[]} existingRolls  Current serialised or live roll array.
+ * @param {Roll[]}          newRolls       Fresh rolls to inject.
+ * @param {typeof Roll}     cleanType      Roll class whose existing entries to evict.
+ * @returns {Roll[]}
+ */
+function _injectRollsToArray(existingRolls, newRolls, cleanType) {
+    if (!CoreUtility.isIterable(newRolls)) {
+        return existingRolls;
     }
+
+    let processedRolls = Array.from(existingRolls);
 
     if (cleanType) {
-        message.rolls = message.rolls.filter(r => !(r instanceof cleanType))
+        processedRolls = processedRolls.filter(r => {
+            const isTargetType = r instanceof cleanType || r.class === cleanType.name;
+            return !isTargetType;
+        });
     }
 
-    message.rolls.push(...rolls);
+    processedRolls.push(...newRolls);
+    return processedRolls;
 }

--- a/src/utils/bonus.js
+++ b/src/utils/bonus.js
@@ -1,3 +1,5 @@
+import { MODULE_SHORT } from "../module/const.js";
+import { ChatUtility } from "./chat.js";
 import { RerollManager } from "./reroll.js";
 
 // Import V2 API
@@ -16,7 +18,6 @@ export class BonusManager {
                 ev.stopPropagation();
             });
 
-        // --- DETECT SECTIONS ---
         const hasAttackSection = $html.find('.rsr-section-attack').length > 0;
         const hasDamageSection = $html.find('.rsr-section-damage').length > 0;
 
@@ -83,14 +84,9 @@ export class BonusManager {
     }
 
     static async openBonusDialog(message, type) {
-        let actor = null;
-        if (message.speaker.token) {
-            const token = game.scenes.get(message.speaker.scene)?.tokens.get(message.speaker.token);
-            actor = token?.actor;
-        } else if (message.speaker.actor) {
-            actor = game.actors.get(message.speaker.actor);
-        }
-
+        // Use ChatUtility.getActorFromMessage for consistent, null-safe actor resolution
+        // that correctly handles unlinked token actors (same fix as was applied in chat.js).
+        const actor = ChatUtility.getActorFromMessage(message);
         if (!actor) return ui.notifications.warn("No actor found for this message.");
         
         const rollData = actor.getRollData();
@@ -183,11 +179,22 @@ export class BonusManager {
                 }
             }
 
-            let targetRollIndex = message.rolls.findIndex(r => type === "damage" ? r instanceof CONFIG.Dice.DamageRoll : r instanceof CONFIG.Dice.D20Roll);
-            if (targetRollIndex === -1) targetRollIndex = message.rolls.length > 0 ? 0 : -1;
+            // RSR stores rolls in message.flags[MODULE_SHORT].rolls, not in message.rolls.
+            // For a processed RSR activity card, message.rolls is empty — the attack and
+            // damage rolls were intercepted and stored in flags by runActivityActions().
+            // ChatUtility.getMessageRolls() reads the flags path first, falling back to
+            // message.rolls for non-RSR messages.
+            const currentRolls = ChatUtility.getMessageRolls(message).map(r => {
+                return r instanceof Roll ? r : Roll.fromData(r);
+            });
+
+            let targetRollIndex = currentRolls.findIndex(r =>
+                type === "damage" ? r instanceof CONFIG.Dice.DamageRoll : r instanceof CONFIG.Dice.D20Roll
+            );
+            if (targetRollIndex === -1) targetRollIndex = currentRolls.length > 0 ? 0 : -1;
             if (targetRollIndex === -1) return ui.notifications.error("No roll found.");
 
-            const originalRoll = message.rolls[targetRollIndex];
+            const originalRoll = currentRolls[targetRollIndex];
             const TargetRollClass = originalRoll.constructor;
             const rollData = actor.getRollData();
             const cleanFormula = this._resolveFormula(bonusDef.rawFormula, rollData);
@@ -208,10 +215,16 @@ export class BonusManager {
             newRoll._total = originalRoll.total + bonusRoll.total;
             newRoll._evaluated = true; 
 
-            const rolls = [...message.rolls];
-            rolls[targetRollIndex] = newRoll;
+            currentRolls[targetRollIndex] = newRoll;
 
-            await message.update({ rolls: rolls });
+            // Persist via flags so the RSR card re-renders from the correct data source.
+            const serialised = currentRolls.map(r => r.toJSON ? r.toJSON() : r);
+            if (message.flags?.[MODULE_SHORT]) {
+                message.flags[MODULE_SHORT].rolls = serialised;
+                await ChatUtility.updateChatMessage(message, { flags: message.flags });
+            } else {
+                await message.update({ rolls: serialised });
+            }
 
             if (type === "initiative") {
                 const combat = game.combats.find(c => c.scene?.id === message.speaker.scene) || game.combat;

--- a/src/utils/bonus.js
+++ b/src/utils/bonus.js
@@ -29,7 +29,6 @@ export class BonusManager {
 
         let injected = false;
 
-        // --- INJECT BUTTONS ---
         if (hasAttackSection) {
             this.injectButton(message, $html, "attack", ".rsr-section-attack");
             injected = true;
@@ -96,48 +95,23 @@ export class BonusManager {
         
         const rollData = actor.getRollData();
         const bonuses = [];
-
-        // --- Auto-Detect if the original roll was a Crit ---
-        let isOriginalCrit = false;
-        if (type === "damage") {
-            const dmgRoll = message.rolls.find(r => r instanceof CONFIG.Dice.DamageRoll || r.options?.critical !== undefined);
-            if (dmgRoll) {
-                isOriginalCrit = dmgRoll.options?.critical === true || 
-                                 dmgRoll.options?.isCritical === true || 
-                                 message.flags?.dnd5e?.roll?.isCritical === true;
-            }
-        }
-
-        // --- 1. COLLECT CANDIDATE EFFECTS (Active Effects Only) ---
-        const candidateEffects = [];
         const actorEffects = actor.appliedEffects || actor.effects; 
-        
-        actorEffects.forEach(e => {
-            if (!e.disabled && !e.isSuppressed) {
-                candidateEffects.push({ effect: e, source: "Actor" });
-            }
-        });
+        const candidateEffects = actorEffects.filter(e => !e.disabled && !e.isSuppressed);
 
-        // --- 2. PROCESS EFFECTS ---
-        for (const entry of candidateEffects) {
-            const effect = entry.effect;
+        for (const effect of candidateEffects) {
             const changes = effect.changes.filter(c => c.key.trim() === "flags.rsr5e-addon.bonus");
-            
             for (const change of changes) {
                 const parts = change.value.split(";").map(s => s.trim());
-                
                 const typePart = parts.find(p => p.toLowerCase().startsWith("type:"));
                 const consumePart = parts.find(p => p.toLowerCase().startsWith("consume"));
                 const isOnce = parts.some(p => p.toLowerCase() === "once");
 
-                // Parse consumption target
                 let consumeTarget = null;
                 if (consumePart) {
                     const split = consumePart.split(":");
                     consumeTarget = split.length > 1 ? split[1].trim() : "origin";
                 }
 
-                // Isolate the formula
                 const formulaParts = parts.filter(p => 
                     !p.toLowerCase().startsWith("type:") && 
                     !p.toLowerCase().startsWith("consume") && 
@@ -157,16 +131,9 @@ export class BonusManager {
                 for (const allowedType of allowedTypes) {
                     if (allowedType === "all" || allowedType === "any") isMatch = true;
                     else if (allowedType === type) isMatch = true;
-                    else if (allowedType === "check") {
-                        if (["skill", "tool", "ability", "check", "initiative"].includes(type)) isMatch = true;
-                    }
-                    else if (allowedType === "save") {
-                        if (["save", "death", "concentration"].includes(type)) isMatch = true;
-                    }
+                    else if (allowedType === "check" && ["skill", "tool", "ability", "check", "initiative"].includes(type)) isMatch = true;
+                    else if (allowedType === "save" && ["save", "death", "concentration"].includes(type)) isMatch = true;
                     else if (type === "check" && ["skill", "tool", "initiative"].includes(allowedType)) isMatch = true;
-                    else if (allowedType === "attack" && type === "attack") isMatch = true;
-                    else if (allowedType === "damage" && type === "damage") isMatch = true;
-
                     if (isMatch) break;
                 }
                 
@@ -185,151 +152,73 @@ export class BonusManager {
             }
         }
 
-        // --- 3. RENDER APPLICATION V2 SELECTOR ---
         new BonusSelector({
             bonuses: bonuses,
             type: type,
-            isCritDefault: isOriginalCrit,
             onSubmit: async (result) => {
-                let bonusDef;
-                
-                if (result.isCustom) {
-                    bonusDef = {
-                        name: "Custom Bonus",
-                        rawFormula: result.formula,
-                        isOnce: false 
-                    };
-                } else {
-                    bonusDef = bonuses[result.index];
-                }
-
-                if (bonusDef) {
-                    await this.applyBonus(message, type, bonusDef, actor, result.applyCrit);
-                }
+                let bonusDef = result.isCustom ? { name: "Custom Bonus", rawFormula: result.formula, isOnce: false } : bonuses[result.index];
+                if (bonusDef) await this.applyBonus(message, type, bonusDef, actor);
             }
         }).render(true);
     }
 
-    static async applyBonus(message, type, bonusDef, actor, applyCrit = false) {
+    static async applyBonus(message, type, bonusDef, actor) {
         try {
-            // --- HANDLE CONSUMPTION FIRST ---
             if (bonusDef.consumeTarget) {
                 let itemToConsume = null;
-
                 if (bonusDef.consumeTarget === "origin" && bonusDef.origin) {
-                    // Extract the Item ID from the end of the origin UUID
                     const parts = bonusDef.origin.split('.');
-                    const itemId = parts[parts.length - 1];
-                    
-                    // Directly fetch the item from the specific token/actor making the roll
-                    itemToConsume = actor.items.get(itemId);
-                    
-                    // Fallback to name-matching if ID fails for any reason
-                    if (!itemToConsume) {
-                        const originDoc = await fromUuid(bonusDef.origin);
-                        if (originDoc && originDoc.documentName === "Item") {
-                            itemToConsume = actor.items.find(i => i.name === originDoc.name);
-                        }
-                    }
+                    itemToConsume = actor.items.get(parts[parts.length - 1]);
                 } else if (bonusDef.consumeTarget !== "origin") {
                     itemToConsume = actor.items.get(bonusDef.consumeTarget) || actor.items.find(i => i.name === bonusDef.consumeTarget);
                 }
 
                 if (itemToConsume) {
                     const uses = itemToConsume.system?.uses;
-                    
-                    // Modern D&D5e (v3.0+) check: uses 'spent' instead of 'value'
-                    if (uses && uses.max) {
-                        const remaining = uses.value; 
-                        const spent = uses.spent || 0; 
-
-                        if (remaining > 0) {
-                            await itemToConsume.update({"system.uses.spent": spent + 1});
-                            ui.notifications.info(`Consumed 1 use from ${itemToConsume.name}.`);
-                        } else {
-                            return ui.notifications.warn(`Cannot apply bonus: ${itemToConsume.name} has no uses left!`);
-                        }
-                    } else {
-                        ui.notifications.warn(`${itemToConsume.name} has no uses configured.`);
+                    if (uses?.max && uses.value > 0) {
+                        await itemToConsume.update({"system.uses.spent": (uses.spent || 0) + 1});
+                    } else if (uses?.max) {
+                        return ui.notifications.warn(`No uses left for ${itemToConsume.name}!`);
                     }
-                } else {
-                    return ui.notifications.error(`Could not find the target item to consume uses from.`);
                 }
             }
 
-            // --- FIND TARGET ROLL FIRST TO INHERIT CONFIGURATION ---
-            let targetRollIndex = -1;
-            if (type === "damage") {
-                targetRollIndex = message.rolls.findIndex(r => r instanceof CONFIG.Dice.DamageRoll);
-            } else {
-                targetRollIndex = message.rolls.findIndex(r => r instanceof CONFIG.Dice.D20Roll);
-            }
-
-            if (targetRollIndex === -1) {
-                if (message.rolls.length > 0) targetRollIndex = 0;
-                else return ui.notifications.error("Could not find target roll in message.");
-            }
+            let targetRollIndex = message.rolls.findIndex(r => type === "damage" ? r instanceof CONFIG.Dice.DamageRoll : r instanceof CONFIG.Dice.D20Roll);
+            if (targetRollIndex === -1) targetRollIndex = message.rolls.length > 0 ? 0 : -1;
+            if (targetRollIndex === -1) return ui.notifications.error("No roll found.");
 
             const originalRoll = message.rolls[targetRollIndex];
             const TargetRollClass = originalRoll.constructor;
-            
-            // Clone the original roll's options to prevent the mergeObject error
-            let rollOptions = foundry.utils.deepClone(originalRoll.options) || {};
-
-            // --- EVALUATE FORMULA ---
             const rollData = actor.getRollData();
             const cleanFormula = this._resolveFormula(bonusDef.rawFormula, rollData);
             
-            if (!cleanFormula || cleanFormula.trim() === "") {
-                return ui.notifications.warn("Invalid bonus formula.");
-            }
+            if (!cleanFormula || cleanFormula.trim() === "") return ui.notifications.warn("Invalid bonus formula.");
 
-            // --- CRIT HANDLING ---
-            if (type === "damage" && applyCrit) {
-                rollOptions.critical = true;
-                rollOptions.multiplyNumeric = game.settings.get("dnd5e", "criticalDamageModifiers") ?? false;
-                rollOptions.maximizeCritical = game.settings.get("dnd5e", "criticalDamageMaxDice") ?? false;
-            }
-
-            // Create the bonus roll securely using the inherited options
-            const bonusRoll = new TargetRollClass(cleanFormula, rollData, rollOptions);
+            const bonusRoll = new TargetRollClass(cleanFormula, rollData, originalRoll.options);
             await bonusRoll.evaluate();
 
-            const originalTerms = originalRoll.terms.map(t => foundry.utils.deepClone(t));
             const newTerms = [
-                ...originalTerms,
+                ...originalRoll.terms.map(t => foundry.utils.deepClone(t)),
                 new foundry.dice.terms.OperatorTerm({operator: "+"}),
                 ...bonusRoll.terms
             ];
 
             const newRoll = TargetRollClass.fromTerms(newTerms);
-            newRoll.options = rollOptions; // Assign the updated options back to the combined roll
+            newRoll.options = foundry.utils.deepClone(originalRoll.options);
             newRoll._total = originalRoll.total + bonusRoll.total;
             newRoll._evaluated = true; 
 
             const rolls = [...message.rolls];
             rolls[targetRollIndex] = newRoll;
 
-            if (message.flags["rsr5e"]) {
-                await message.update({ rolls: rolls });
-            } else {
-                const newContent = await newRoll.render();
-                await message.update({ rolls: rolls, content: newContent });
-            }
+            await message.update({ rolls: rolls });
 
             if (type === "initiative") {
-                const messageSceneId = message.speaker.scene;
-                const targetCombat = game.combats.find(c => c.scene?.id === messageSceneId) || game.combat;
-                if (targetCombat) {
-                    const combatant = targetCombat.combatants.find(c => 
-                        (c.tokenId && c.tokenId === message.speaker.token) || 
-                        (c.actorId && c.actorId === message.speaker.actor)
-                    );
-                    if (combatant) await targetCombat.setInitiative(combatant.id, newRoll.total);
-                }
+                const combat = game.combats.find(c => c.scene?.id === message.speaker.scene) || game.combat;
+                const combatant = combat?.combatants.find(c => c.tokenId === message.speaker.token || c.actorId === message.speaker.actor);
+                if (combatant) await combat.setInitiative(combatant.id, newRoll.total);
             }
 
-            // Clean up if it was a one-time effect
             if (bonusDef.isOnce && bonusDef.effectId) {
                 const effect = actor.effects.get(bonusDef.effectId);
                 if (effect) await effect.delete();
@@ -337,180 +226,94 @@ export class BonusManager {
             ui.notifications.info(`Applied ${bonusDef.name} (+${bonusRoll.total}).`);
 
         } catch (err) {
-            console.error("RSR Addon | Error applying bonus:", err);
+            console.error("RSR Addon | Error:", err);
             ui.notifications.error(`Error applying bonus: ${err.message}`);
         }
     }
 
-    static _resolveFormula(formula, rollData, logging = false) {
+    static _resolveFormula(formula, rollData) {
         if (!formula || typeof formula !== 'string' || !formula.includes("@")) return formula;
-        
         return formula.replace(/@([a-zA-Z0-9._-]+)/g, (match, term) => {
             let value = foundry.utils.getProperty(rollData, term);
             if (value === undefined) return match;
-
             if (typeof value === 'object' && value !== null) {
                 if ('number' in value && 'faces' in value) return `${value.number}d${value.faces}`;
-                if ('number' in value && 'die' in value) return `${value.number}${value.die}`;
-                if ('value' in value) return value.value;
-                if ('total' in value) return value.total;
-                if ('formula' in value) return value.formula;
-                return "0"; 
+                return value.value ?? "0"; 
             }
             return String(value);
         });
     }
 }
 
-// ==========================================================
-//  APPLICATION V2 CLASS
-// ==========================================================
 class BonusSelector extends ApplicationV2 {
     constructor(options) {
         super(options);
         this.bonuses = options.bonuses;
         this.type = options.type;
-        this.isCritDefault = options.isCritDefault || false; 
         this.onSubmitCallback = options.onSubmit;
     }
 
     static DEFAULT_OPTIONS = {
-        tag: "form",
-        id: "rsr-bonus-selector",
-        classes: ["rsr-bonus-window"],
-        window: {
-            title: "Apply Retroactive Bonus",
-            icon: "fas fa-dice-d20",
-            resizable: false,
-            width: 440
-        },
-        position: {
-            width: 440,
-            height: "auto"
-        },
-        form: {
-            handler: BonusSelector.prototype._handleSubmit,
-            closeOnSubmit: true
-        }
+        tag: "form", id: "rsr-bonus-selector", classes: ["rsr-bonus-window"],
+        window: { title: "Apply Retroactive Bonus", icon: "fas fa-dice-d20", resizable: false, width: 400 },
+        position: { width: 400, height: "auto" },
+        form: { handler: BonusSelector.prototype._handleSubmit, closeOnSubmit: true }
     };
 
-    async _renderHTML(context, options) {
+    async _renderHTML() {
+        const customChecked = this.bonuses.length === 0 ? "checked" : "";
         let html = `
         <div class="rsr-bonus-content" style="padding: 10px; display: flex; flex-direction: column; gap: 10px;">
-            <p style="margin: 0; color: var(--color-text-primary);">
-                Select a bonus to apply to the <strong>${this.type} roll</strong>:
-            </p>
+            <p>Select a bonus for the <strong>${this.type} roll</strong>:</p>
             <div class="rsr-bonus-list" style="display: flex; flex-direction: column; gap: 6px;">
-        `;
-
-        const customIcon = "icons/magic/life/crosses-trio-red.webp";
-        const customChecked = this.bonuses.length === 0 ? "checked" : "";
-        
-        html += `
-            <div class="form-group" style="display:flex; flex-direction: column; padding: 8px; border: 1px solid var(--color-border-light-2); border-radius: 4px; background: var(--color-bg-light);">
-                <div style="display:flex; align-items:center;">
-                    <input type="radio" name="bonusIndex" value="custom" id="bonus-custom" ${customChecked} style="margin-right: 12px;">
-                    <label for="bonus-custom" style="display:flex; align-items:center; cursor:pointer; flex:1; margin:0; user-select: none;">
-                        <img src="${customIcon}" width="32" height="32" style="border:none; margin-right:12px; flex-shrink:0;">
-                        <span style="font-weight:bold; font-size: 1.1em; color: var(--color-text-primary);">Custom Bonus</span>
-                    </label>
-                </div>
-                
-                <div class="custom-input-container" style="margin-top: 8px; margin-left: 44px; display: ${customChecked ? 'block' : 'none'};">
-                    <input type="text" name="customFormula" placeholder="e.g. +5 or 1d4" style="width: 100%; box-sizing: border-box; background: var(--color-bg-light); color: var(--color-text-primary); border: 1px solid var(--color-border-dark);">
-                </div>
-            </div>`;
+                <div class="form-group" style="padding: 8px; border: 1px solid var(--color-border-light-2); border-radius: 4px; background: var(--color-bg-light);">
+                    <div style="display:flex; align-items:center;">
+                        <input type="radio" name="bonusIndex" value="custom" id="bonus-custom" ${customChecked}>
+                        <label for="bonus-custom" style="display:flex; align-items:center; cursor:pointer; flex:1; margin-left:12px;">
+                            <img src="icons/magic/life/crosses-trio-red.webp" width="32" height="32" style="border:none; margin-right:12px;">
+                            <strong>Custom Bonus</strong>
+                        </label>
+                    </div>
+                    <div class="custom-input-container" style="margin-top: 8px; margin-left: 44px; display: ${customChecked ? 'block' : 'none'};">
+                        <input type="text" name="customFormula" placeholder="e.g. +5 or 1d4" style="width: 100%;">
+                    </div>
+                </div>`;
 
         this.bonuses.forEach((b, i) => {
-            const displayFormula = b.rawFormula !== b.resolvedFormula 
-                ? `${b.rawFormula} ⮕ <strong>${b.resolvedFormula}</strong>` 
-                : b.rawFormula;
-            
-            const checked = (i === 0) ? "checked" : "";
-
             html += `
-            <div class="form-group" style="display:flex; align-items:center; padding: 8px; border: 1px solid var(--color-border-light-2); border-radius: 4px; background: var(--color-bg-light);">
-                <input type="radio" name="bonusIndex" value="${i}" id="bonus-${i}" ${checked} style="margin-right: 12px;">
-                <label for="bonus-${i}" style="display:flex; align-items:center; cursor:pointer; flex:1; margin:0; user-select: none;">
-                    <img src="${b.icon}" width="32" height="32" style="border:none; margin-right:12px; flex-shrink:0;">
-                    <div style="display:flex; flex-direction:column; justify-content:center;">
-                        <span style="font-weight:bold; font-size: 1.1em; line-height: 1.2; color: var(--color-text-primary);">${b.name}</span>
-                        <span style="font-size:0.9em; color: var(--color-text-secondary);">${displayFormula}</span>
-                    </div>
-                </label>
-            </div>`;
+                <div class="form-group" style="display:flex; align-items:center; padding: 8px; border: 1px solid var(--color-border-light-2); border-radius: 4px; background: var(--color-bg-light);">
+                    <input type="radio" name="bonusIndex" value="${i}" id="bonus-${i}" ${i === 0 && !customChecked ? "checked" : ""}>
+                    <label for="bonus-${i}" style="display:flex; align-items:center; cursor:pointer; flex:1; margin-left:12px;">
+                        <img src="${b.icon}" width="32" height="32" style="border:none; margin-right:12px;">
+                        <div><strong>${b.name}</strong><br><small>${b.rawFormula}</small></div>
+                    </label>
+                </div>`;
         });
 
-        html += `</div>`; 
-
-        if (this.type === "damage") {
-            const critChecked = this.isCritDefault ? "checked" : "";
-            html += `
-            <div class="form-group" style="display:flex; align-items:center; margin-top: 5px; padding: 10px; border: 1px solid var(--color-border-highlight); border-radius: 4px; background: rgba(255, 0, 0, 0.05);">
-                <input type="checkbox" name="applyCrit" id="applyCrit" ${critChecked} style="margin-right: 12px; width: 16px; height: 16px; cursor:pointer;">
-                <label for="applyCrit" style="cursor:pointer; font-weight:bold; color: var(--color-text-primary); margin:0; user-select:none; display:flex; align-items:center;">
-                    <i class="fas fa-bullseye" style="color: var(--color-text-danger); margin-right: 8px;"></i>
-                    Roll as Critical Hit
-                </label>
-            </div>`;
-        }
-
         html += `
-            <div class="form-footer" style="margin-top: 10px; display: flex; justify-content: flex-end;">
-                <button type="submit" class="save" style="width: auto; min-width: 120px;">
-                    <i class="fas fa-dice-d20"></i> Apply Bonus
-                </button>
             </div>
-        </div>
-        `;
+            <footer class="form-footer" style="margin-top: 10px; display: flex; justify-content: flex-end;">
+                <button type="submit" style="width: auto;"><i class="fas fa-dice-d20"></i> Apply Bonus</button>
+            </footer>
+        </div>`;
 
         const div = document.createElement("div");
         div.innerHTML = html;
-
-        const customInputContainer = div.querySelector('.custom-input-container');
-        const customInput = div.querySelector('input[name="customFormula"]');
-        const allRadios = div.querySelectorAll('input[name="bonusIndex"]');
-
-        allRadios.forEach(radio => {
-            radio.addEventListener('change', (e) => {
-                if (e.target.value === "custom") {
-                    customInputContainer.style.display = 'block';
-                    customInput.focus();
-                } else {
-                    customInputContainer.style.display = 'none';
-                }
-            });
+        div.querySelectorAll('input[name="bonusIndex"]').forEach(r => {
+            r.addEventListener('change', e => div.querySelector('.custom-input-container').style.display = e.target.value === "custom" ? 'block' : 'none');
         });
-
         return div;
     }
 
-    _replaceHTML(result, content, options) {
-        content.replaceChildren(result);
-    }
+    _replaceHTML(result, content) { content.replaceChildren(result); }
 
     async _handleSubmit(event, form, formData) {
-        const indexValue = formData.object.bonusIndex;
-        const customFormula = formData.object.customFormula;
-        const applyCrit = formData.object.applyCrit === true || formData.object.applyCrit === "on";
-
         if (this.onSubmitCallback) {
-            if (indexValue === "custom") {
-                if (!customFormula || customFormula.trim() === "") {
-                    return ui.notifications.warn("Please enter a custom bonus formula.");
-                }
-                
-                await this.onSubmitCallback({
-                    isCustom: true,
-                    formula: customFormula,
-                    applyCrit: applyCrit
-                });
-            } else if (indexValue !== undefined) {
-                await this.onSubmitCallback({
-                    isCustom: false,
-                    index: parseInt(indexValue),
-                    applyCrit: applyCrit
-                });
+            if (formData.object.bonusIndex === "custom") {
+                if (!formData.object.customFormula) return ui.notifications.warn("Enter formula.");
+                await this.onSubmitCallback({ isCustom: true, formula: formData.object.customFormula });
+            } else {
+                await this.onSubmitCallback({ isCustom: false, index: parseInt(formData.object.bonusIndex) });
             }
         }
     }

--- a/src/utils/bonus.js
+++ b/src/utils/bonus.js
@@ -1,0 +1,517 @@
+import { RerollManager } from "./reroll.js";
+
+// Import V2 API
+const { ApplicationV2 } = foundry.applications.api;
+
+export class BonusManager {
+    static init(message, html) {
+        const $html = html instanceof HTMLElement ? $(html) : html;
+
+        if (!message.isAuthor && !game.user.isGM) return false;
+        if (!$html || $html.length === 0) return false;
+
+        $html.find('.rsr-damage-buttons button, .rsr-damage-buttons-xl button')
+            .off('click.rsrFix')
+            .on('click.rsrFix', (ev) => {
+                ev.stopPropagation();
+            });
+
+        // --- DETECT SECTIONS ---
+        const hasAttackSection = $html.find('.rsr-section-attack').length > 0;
+        const hasDamageSection = $html.find('.rsr-section-damage').length > 0;
+
+        const isDnd5eRoll = !!message.flags.dnd5e?.roll?.type;
+        const isInitiative = message.flags.core?.initiativeRoll || 
+                             (message.flavor && message.flavor.includes("Initiative")) ||
+                             $html.find('.dice-flavor').text().includes("Initiative");
+
+        if (!hasAttackSection && !hasDamageSection && !isDnd5eRoll && !isInitiative) return false;
+
+        let injected = false;
+
+        // --- INJECT BUTTONS ---
+        if (hasAttackSection) {
+            this.injectButton(message, $html, "attack", ".rsr-section-attack");
+            injected = true;
+        }
+        
+        if (hasDamageSection) {
+            this.injectButton(message, $html, "damage", ".rsr-section-damage");
+            injected = true;
+        }
+
+        let rollType = null;
+        if (isInitiative) rollType = "initiative";
+        else if (isDnd5eRoll) rollType = message.flags.dnd5e.roll.type;
+
+        const validTypes = ["skill", "tool", "ability", "save", "death", "concentration", "initiative"];
+
+        if (rollType && validTypes.includes(rollType)) {
+            const label = rollType === "ability" ? "check" : rollType;
+            this.injectButton(message, $html, label, ".message-header");
+            injected = true;
+        }
+
+        return injected;
+    }
+
+    static injectButton(message, html, type, sectionSelector) {
+        const section = html.find(sectionSelector);
+        if (section.length === 0) return;
+
+        if (section.find(`.rsr-addon-bonus-btn[data-type="${type}"]`).length > 0) return;
+
+        let container = section.find('.rsr-header .rsr-title').first();
+        if (container.length === 0) container = section.find('.rsr-header').first();
+        if (container.length === 0) container = section.find('.message-sender').first(); 
+        if (container.length === 0) container = section; 
+
+        const titleType = type.charAt(0).toUpperCase() + type.slice(1);
+        const btn = $(`<i class="fas fa-plus-circle rsr-addon-bonus-btn" data-type="${type}" title="Add Bonus to ${titleType}"></i>`);
+        
+        if (sectionSelector === ".message-header") {
+            btn.css({ "margin-left": "8px", "align-self": "center", "font-size": "1.2em", "order": "10", "cursor": "pointer" });
+            section.append(btn);
+        } else {
+            container.append(btn);
+        }
+        
+        btn.click((ev) => {
+            ev.preventDefault();
+            ev.stopPropagation(); 
+            this.openBonusDialog(message, type);
+        });
+    }
+
+    static async openBonusDialog(message, type) {
+        let actor = null;
+        if (message.speaker.token) {
+            const token = game.scenes.get(message.speaker.scene)?.tokens.get(message.speaker.token);
+            actor = token?.actor;
+        } else if (message.speaker.actor) {
+            actor = game.actors.get(message.speaker.actor);
+        }
+
+        if (!actor) return ui.notifications.warn("No actor found for this message.");
+        
+        const rollData = actor.getRollData();
+        const bonuses = [];
+
+        // --- Auto-Detect if the original roll was a Crit ---
+        let isOriginalCrit = false;
+        if (type === "damage") {
+            const dmgRoll = message.rolls.find(r => r instanceof CONFIG.Dice.DamageRoll || r.options?.critical !== undefined);
+            if (dmgRoll) {
+                isOriginalCrit = dmgRoll.options?.critical === true || 
+                                 dmgRoll.options?.isCritical === true || 
+                                 message.flags?.dnd5e?.roll?.isCritical === true;
+            }
+        }
+
+        // --- 1. COLLECT CANDIDATE EFFECTS (Active Effects Only) ---
+        const candidateEffects = [];
+        const actorEffects = actor.appliedEffects || actor.effects; 
+        
+        actorEffects.forEach(e => {
+            if (!e.disabled && !e.isSuppressed) {
+                candidateEffects.push({ effect: e, source: "Actor" });
+            }
+        });
+
+        // --- 2. PROCESS EFFECTS ---
+        for (const entry of candidateEffects) {
+            const effect = entry.effect;
+            const changes = effect.changes.filter(c => c.key.trim() === "flags.rsr5e-addon.bonus");
+            
+            for (const change of changes) {
+                const parts = change.value.split(";").map(s => s.trim());
+                
+                const typePart = parts.find(p => p.toLowerCase().startsWith("type:"));
+                const consumePart = parts.find(p => p.toLowerCase().startsWith("consume"));
+                const isOnce = parts.some(p => p.toLowerCase() === "once");
+
+                // Parse consumption target
+                let consumeTarget = null;
+                if (consumePart) {
+                    const split = consumePart.split(":");
+                    consumeTarget = split.length > 1 ? split[1].trim() : "origin";
+                }
+
+                // Isolate the formula
+                const formulaParts = parts.filter(p => 
+                    !p.toLowerCase().startsWith("type:") && 
+                    !p.toLowerCase().startsWith("consume") && 
+                    p.toLowerCase() !== "once"
+                );
+                
+                let rawFormula = formulaParts.length > 0 ? formulaParts[0] : "0";
+                const resolvedFormula = this._resolveFormula(rawFormula, rollData);
+
+                let allowedTypes = ["any"];
+                if (typePart) {
+                    const typeString = typePart.split(":")[1];
+                    allowedTypes = typeString.split(",").map(t => t.trim().toLowerCase());
+                }
+
+                let isMatch = false;
+                for (const allowedType of allowedTypes) {
+                    if (allowedType === "all" || allowedType === "any") isMatch = true;
+                    else if (allowedType === type) isMatch = true;
+                    else if (allowedType === "check") {
+                        if (["skill", "tool", "ability", "check", "initiative"].includes(type)) isMatch = true;
+                    }
+                    else if (allowedType === "save") {
+                        if (["save", "death", "concentration"].includes(type)) isMatch = true;
+                    }
+                    else if (type === "check" && ["skill", "tool", "initiative"].includes(allowedType)) isMatch = true;
+                    else if (allowedType === "attack" && type === "attack") isMatch = true;
+                    else if (allowedType === "damage" && type === "damage") isMatch = true;
+
+                    if (isMatch) break;
+                }
+                
+                if (isMatch) {
+                    bonuses.push({
+                        effectId: effect.id,
+                        origin: effect.origin,
+                        name: effect.name,
+                        icon: effect.img || effect.icon || "icons/svg/aura.svg",
+                        rawFormula: rawFormula,
+                        resolvedFormula: resolvedFormula,
+                        isOnce: isOnce,
+                        consumeTarget: consumeTarget
+                    });
+                }
+            }
+        }
+
+        // --- 3. RENDER APPLICATION V2 SELECTOR ---
+        new BonusSelector({
+            bonuses: bonuses,
+            type: type,
+            isCritDefault: isOriginalCrit,
+            onSubmit: async (result) => {
+                let bonusDef;
+                
+                if (result.isCustom) {
+                    bonusDef = {
+                        name: "Custom Bonus",
+                        rawFormula: result.formula,
+                        isOnce: false 
+                    };
+                } else {
+                    bonusDef = bonuses[result.index];
+                }
+
+                if (bonusDef) {
+                    await this.applyBonus(message, type, bonusDef, actor, result.applyCrit);
+                }
+            }
+        }).render(true);
+    }
+
+    static async applyBonus(message, type, bonusDef, actor, applyCrit = false) {
+        try {
+            // --- HANDLE CONSUMPTION FIRST ---
+            if (bonusDef.consumeTarget) {
+                let itemToConsume = null;
+
+                if (bonusDef.consumeTarget === "origin" && bonusDef.origin) {
+                    // Extract the Item ID from the end of the origin UUID
+                    const parts = bonusDef.origin.split('.');
+                    const itemId = parts[parts.length - 1];
+                    
+                    // Directly fetch the item from the specific token/actor making the roll
+                    itemToConsume = actor.items.get(itemId);
+                    
+                    // Fallback to name-matching if ID fails for any reason
+                    if (!itemToConsume) {
+                        const originDoc = await fromUuid(bonusDef.origin);
+                        if (originDoc && originDoc.documentName === "Item") {
+                            itemToConsume = actor.items.find(i => i.name === originDoc.name);
+                        }
+                    }
+                } else if (bonusDef.consumeTarget !== "origin") {
+                    itemToConsume = actor.items.get(bonusDef.consumeTarget) || actor.items.find(i => i.name === bonusDef.consumeTarget);
+                }
+
+                if (itemToConsume) {
+                    const uses = itemToConsume.system?.uses;
+                    
+                    // Modern D&D5e (v3.0+) check: uses 'spent' instead of 'value'
+                    if (uses && uses.max) {
+                        const remaining = uses.value; 
+                        const spent = uses.spent || 0; 
+
+                        if (remaining > 0) {
+                            await itemToConsume.update({"system.uses.spent": spent + 1});
+                            ui.notifications.info(`Consumed 1 use from ${itemToConsume.name}.`);
+                        } else {
+                            return ui.notifications.warn(`Cannot apply bonus: ${itemToConsume.name} has no uses left!`);
+                        }
+                    } else {
+                        ui.notifications.warn(`${itemToConsume.name} has no uses configured.`);
+                    }
+                } else {
+                    return ui.notifications.error(`Could not find the target item to consume uses from.`);
+                }
+            }
+
+            // --- FIND TARGET ROLL FIRST TO INHERIT CONFIGURATION ---
+            let targetRollIndex = -1;
+            if (type === "damage") {
+                targetRollIndex = message.rolls.findIndex(r => r instanceof CONFIG.Dice.DamageRoll);
+            } else {
+                targetRollIndex = message.rolls.findIndex(r => r instanceof CONFIG.Dice.D20Roll);
+            }
+
+            if (targetRollIndex === -1) {
+                if (message.rolls.length > 0) targetRollIndex = 0;
+                else return ui.notifications.error("Could not find target roll in message.");
+            }
+
+            const originalRoll = message.rolls[targetRollIndex];
+            const TargetRollClass = originalRoll.constructor;
+            
+            // Clone the original roll's options to prevent the mergeObject error
+            let rollOptions = foundry.utils.deepClone(originalRoll.options) || {};
+
+            // --- EVALUATE FORMULA ---
+            const rollData = actor.getRollData();
+            const cleanFormula = this._resolveFormula(bonusDef.rawFormula, rollData);
+            
+            if (!cleanFormula || cleanFormula.trim() === "") {
+                return ui.notifications.warn("Invalid bonus formula.");
+            }
+
+            // --- CRIT HANDLING ---
+            if (type === "damage" && applyCrit) {
+                rollOptions.critical = true;
+                rollOptions.multiplyNumeric = game.settings.get("dnd5e", "criticalDamageModifiers") ?? false;
+                rollOptions.maximizeCritical = game.settings.get("dnd5e", "criticalDamageMaxDice") ?? false;
+            }
+
+            // Create the bonus roll securely using the inherited options
+            const bonusRoll = new TargetRollClass(cleanFormula, rollData, rollOptions);
+            await bonusRoll.evaluate();
+
+            const originalTerms = originalRoll.terms.map(t => foundry.utils.deepClone(t));
+            const newTerms = [
+                ...originalTerms,
+                new foundry.dice.terms.OperatorTerm({operator: "+"}),
+                ...bonusRoll.terms
+            ];
+
+            const newRoll = TargetRollClass.fromTerms(newTerms);
+            newRoll.options = rollOptions; // Assign the updated options back to the combined roll
+            newRoll._total = originalRoll.total + bonusRoll.total;
+            newRoll._evaluated = true; 
+
+            const rolls = [...message.rolls];
+            rolls[targetRollIndex] = newRoll;
+
+            if (message.flags["rsr5e"]) {
+                await message.update({ rolls: rolls });
+            } else {
+                const newContent = await newRoll.render();
+                await message.update({ rolls: rolls, content: newContent });
+            }
+
+            if (type === "initiative") {
+                const messageSceneId = message.speaker.scene;
+                const targetCombat = game.combats.find(c => c.scene?.id === messageSceneId) || game.combat;
+                if (targetCombat) {
+                    const combatant = targetCombat.combatants.find(c => 
+                        (c.tokenId && c.tokenId === message.speaker.token) || 
+                        (c.actorId && c.actorId === message.speaker.actor)
+                    );
+                    if (combatant) await targetCombat.setInitiative(combatant.id, newRoll.total);
+                }
+            }
+
+            // Clean up if it was a one-time effect
+            if (bonusDef.isOnce && bonusDef.effectId) {
+                const effect = actor.effects.get(bonusDef.effectId);
+                if (effect) await effect.delete();
+            }
+            ui.notifications.info(`Applied ${bonusDef.name} (+${bonusRoll.total}).`);
+
+        } catch (err) {
+            console.error("RSR Addon | Error applying bonus:", err);
+            ui.notifications.error(`Error applying bonus: ${err.message}`);
+        }
+    }
+
+    static _resolveFormula(formula, rollData, logging = false) {
+        if (!formula || typeof formula !== 'string' || !formula.includes("@")) return formula;
+        
+        return formula.replace(/@([a-zA-Z0-9._-]+)/g, (match, term) => {
+            let value = foundry.utils.getProperty(rollData, term);
+            if (value === undefined) return match;
+
+            if (typeof value === 'object' && value !== null) {
+                if ('number' in value && 'faces' in value) return `${value.number}d${value.faces}`;
+                if ('number' in value && 'die' in value) return `${value.number}${value.die}`;
+                if ('value' in value) return value.value;
+                if ('total' in value) return value.total;
+                if ('formula' in value) return value.formula;
+                return "0"; 
+            }
+            return String(value);
+        });
+    }
+}
+
+// ==========================================================
+//  APPLICATION V2 CLASS
+// ==========================================================
+class BonusSelector extends ApplicationV2 {
+    constructor(options) {
+        super(options);
+        this.bonuses = options.bonuses;
+        this.type = options.type;
+        this.isCritDefault = options.isCritDefault || false; 
+        this.onSubmitCallback = options.onSubmit;
+    }
+
+    static DEFAULT_OPTIONS = {
+        tag: "form",
+        id: "rsr-bonus-selector",
+        classes: ["rsr-bonus-window"],
+        window: {
+            title: "Apply Retroactive Bonus",
+            icon: "fas fa-dice-d20",
+            resizable: false,
+            width: 440
+        },
+        position: {
+            width: 440,
+            height: "auto"
+        },
+        form: {
+            handler: BonusSelector.prototype._handleSubmit,
+            closeOnSubmit: true
+        }
+    };
+
+    async _renderHTML(context, options) {
+        let html = `
+        <div class="rsr-bonus-content" style="padding: 10px; display: flex; flex-direction: column; gap: 10px;">
+            <p style="margin: 0; color: var(--color-text-primary);">
+                Select a bonus to apply to the <strong>${this.type} roll</strong>:
+            </p>
+            <div class="rsr-bonus-list" style="display: flex; flex-direction: column; gap: 6px;">
+        `;
+
+        const customIcon = "icons/magic/life/crosses-trio-red.webp";
+        const customChecked = this.bonuses.length === 0 ? "checked" : "";
+        
+        html += `
+            <div class="form-group" style="display:flex; flex-direction: column; padding: 8px; border: 1px solid var(--color-border-light-2); border-radius: 4px; background: var(--color-bg-light);">
+                <div style="display:flex; align-items:center;">
+                    <input type="radio" name="bonusIndex" value="custom" id="bonus-custom" ${customChecked} style="margin-right: 12px;">
+                    <label for="bonus-custom" style="display:flex; align-items:center; cursor:pointer; flex:1; margin:0; user-select: none;">
+                        <img src="${customIcon}" width="32" height="32" style="border:none; margin-right:12px; flex-shrink:0;">
+                        <span style="font-weight:bold; font-size: 1.1em; color: var(--color-text-primary);">Custom Bonus</span>
+                    </label>
+                </div>
+                
+                <div class="custom-input-container" style="margin-top: 8px; margin-left: 44px; display: ${customChecked ? 'block' : 'none'};">
+                    <input type="text" name="customFormula" placeholder="e.g. +5 or 1d4" style="width: 100%; box-sizing: border-box; background: var(--color-bg-light); color: var(--color-text-primary); border: 1px solid var(--color-border-dark);">
+                </div>
+            </div>`;
+
+        this.bonuses.forEach((b, i) => {
+            const displayFormula = b.rawFormula !== b.resolvedFormula 
+                ? `${b.rawFormula} ⮕ <strong>${b.resolvedFormula}</strong>` 
+                : b.rawFormula;
+            
+            const checked = (i === 0) ? "checked" : "";
+
+            html += `
+            <div class="form-group" style="display:flex; align-items:center; padding: 8px; border: 1px solid var(--color-border-light-2); border-radius: 4px; background: var(--color-bg-light);">
+                <input type="radio" name="bonusIndex" value="${i}" id="bonus-${i}" ${checked} style="margin-right: 12px;">
+                <label for="bonus-${i}" style="display:flex; align-items:center; cursor:pointer; flex:1; margin:0; user-select: none;">
+                    <img src="${b.icon}" width="32" height="32" style="border:none; margin-right:12px; flex-shrink:0;">
+                    <div style="display:flex; flex-direction:column; justify-content:center;">
+                        <span style="font-weight:bold; font-size: 1.1em; line-height: 1.2; color: var(--color-text-primary);">${b.name}</span>
+                        <span style="font-size:0.9em; color: var(--color-text-secondary);">${displayFormula}</span>
+                    </div>
+                </label>
+            </div>`;
+        });
+
+        html += `</div>`; 
+
+        if (this.type === "damage") {
+            const critChecked = this.isCritDefault ? "checked" : "";
+            html += `
+            <div class="form-group" style="display:flex; align-items:center; margin-top: 5px; padding: 10px; border: 1px solid var(--color-border-highlight); border-radius: 4px; background: rgba(255, 0, 0, 0.05);">
+                <input type="checkbox" name="applyCrit" id="applyCrit" ${critChecked} style="margin-right: 12px; width: 16px; height: 16px; cursor:pointer;">
+                <label for="applyCrit" style="cursor:pointer; font-weight:bold; color: var(--color-text-primary); margin:0; user-select:none; display:flex; align-items:center;">
+                    <i class="fas fa-bullseye" style="color: var(--color-text-danger); margin-right: 8px;"></i>
+                    Roll as Critical Hit
+                </label>
+            </div>`;
+        }
+
+        html += `
+            <div class="form-footer" style="margin-top: 10px; display: flex; justify-content: flex-end;">
+                <button type="submit" class="save" style="width: auto; min-width: 120px;">
+                    <i class="fas fa-dice-d20"></i> Apply Bonus
+                </button>
+            </div>
+        </div>
+        `;
+
+        const div = document.createElement("div");
+        div.innerHTML = html;
+
+        const customInputContainer = div.querySelector('.custom-input-container');
+        const customInput = div.querySelector('input[name="customFormula"]');
+        const allRadios = div.querySelectorAll('input[name="bonusIndex"]');
+
+        allRadios.forEach(radio => {
+            radio.addEventListener('change', (e) => {
+                if (e.target.value === "custom") {
+                    customInputContainer.style.display = 'block';
+                    customInput.focus();
+                } else {
+                    customInputContainer.style.display = 'none';
+                }
+            });
+        });
+
+        return div;
+    }
+
+    _replaceHTML(result, content, options) {
+        content.replaceChildren(result);
+    }
+
+    async _handleSubmit(event, form, formData) {
+        const indexValue = formData.object.bonusIndex;
+        const customFormula = formData.object.customFormula;
+        const applyCrit = formData.object.applyCrit === true || formData.object.applyCrit === "on";
+
+        if (this.onSubmitCallback) {
+            if (indexValue === "custom") {
+                if (!customFormula || customFormula.trim() === "") {
+                    return ui.notifications.warn("Please enter a custom bonus formula.");
+                }
+                
+                await this.onSubmitCallback({
+                    isCustom: true,
+                    formula: customFormula,
+                    applyCrit: applyCrit
+                });
+            } else if (indexValue !== undefined) {
+                await this.onSubmitCallback({
+                    isCustom: false,
+                    index: parseInt(indexValue),
+                    applyCrit: applyCrit
+                });
+            }
+        }
+    }
+}

--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -9,52 +9,54 @@ import { RenderUtility } from "./render.js";
 import { ROLL_STATE, ROLL_TYPE, RollUtility } from "./roll.js";
 import { SETTING_NAMES, SettingsUtility } from "./settings.js";
 
-/**
- * Enumerable of identifiers for different message types that can be made.
- * @enum {String}
- */
 export const MESSAGE_TYPE = {
     ROLL: "roll",
     USAGE: "usage",
 }
 
-/**
- * Utility class to handle binding chat cards for use by the module.
- */
 export class ChatUtility {
-    /**
-     * Process a given chat message, adding module content and events to it.
-     * Does nothing if the message is not the correct type.
-     * @param {ChatMessage} message The chat message to process.
-     * @param {JQuery} html The object data for the chat message.
-     */
+    static getMessageRolls(message) {
+        const flagRolls = message.flags?.[MODULE_SHORT]?.rolls;
+        if (flagRolls && Array.isArray(flagRolls)) {
+            return flagRolls.map(r => {
+                if (r instanceof Roll) return r;
+                try { return Roll.fromData(r); } catch(e) { return null; }
+            }).filter(r => r);
+        }
+        return Array.from(message.rolls || []);
+    }
+
     static async processChatMessage(message, html) {
-        if (!message || !html) {
-            return;
+        if (!message || !html) return;
+        
+        if (!message.flags) message.flags = {};
+
+        const type = ChatUtility.getMessageType(message);
+
+        if (type === ROLL_TYPE.ACTIVITY && message.isAuthor) {
+            message.flags[MODULE_SHORT] = message.flags[MODULE_SHORT] || {};
+            if (message.flags[MODULE_SHORT].quickRoll === undefined) {
+                message.flags[MODULE_SHORT].quickRoll = !SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_VANILLA_ENABLED);
+                message.flags[MODULE_SHORT].processed = false;
+
+                const activity = ActivityUtility._getActivityFromMessage(message);
+                if (activity) {
+                    ActivityUtility.setRenderFlags(activity, message);
+                }
+            }
         }
 
-        if (!message.flags || Object.keys(message.flags).length === 0) {
-            return;
-        }
-
-        if (SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_VANILLA_ENABLED) && !message.flags[MODULE_SHORT]) {
+        if (SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_VANILLA_ENABLED) && (!message.flags[MODULE_SHORT] || !message.flags[MODULE_SHORT].quickRoll)) {
             _processVanillaMessage(message);
             await $(html).addClass("rsr-hide");
         }
 
-        if (!message.flags[MODULE_SHORT] || !message.flags[MODULE_SHORT].quickRoll) {
-            return;
-        }
+        if (!message.flags[MODULE_SHORT] || !message.flags[MODULE_SHORT].quickRoll) return;
 
-        const type = ChatUtility.getMessageType(message);
-
-       // Hide the message if we haven't yet finished processing RSR content
         if (!message.flags[MODULE_SHORT].processed) {
             await $(html).addClass("rsr-hide");
 
-            if (type == ROLL_TYPE.ACTIVITY && message.isAuthor)
-            {
-                // FIX: MUTEX LOCK to prevent AC5e from causing concurrent re-rolls
+            if (type == ROLL_TYPE.ACTIVITY && message.isAuthor) {
                 if (message._rsrIsProcessing) return;
                 message._rsrIsProcessing = true;
 
@@ -63,42 +65,38 @@ export class ChatUtility {
                     if (activityType == ROLL_TYPE.ATTACK || (activityType == ROLL_TYPE.ABILITY_SAVE && message.flags[MODULE_SHORT].renderDamage)) {
                         message.flags[MODULE_SHORT].processed = true;
                     } else {
-                        // FIX: Added missing await
                         await ActivityUtility.runActivityActions(message);
                     }  
                 } else {
-                    // FIX: Added missing await
                     await ActivityUtility.runActivityActions(message);
                 }                
             }
-
             return;
         }
 
-        if (game.dice3d && game.dice3d.isEnabled() && message._dice3danimating)
-        {
+        // dnd5e 5.3.0: For usage (ACTIVITY) messages, ChatMessage5e.renderHTML() calls
+        // this.system.getHTML() AFTER firing the renderChatMessageHTML hook. system.getHTML()
+        // completely replaces .message-content innerHTML with the rendered usage-card template,
+        // destroying any content RSR injects here. RSR's injection for usage cards is therefore
+        // deferred to the dnd5e.renderChatMessage hook (via processUsageChatMessage), which
+        // fires after system.getHTML() has finished and the DOM is stable.
+        if (type === ROLL_TYPE.ACTIVITY) return;
+
+        if (game.dice3d && game.dice3d.isEnabled() && message._dice3danimating) {
             await $(html).addClass("rsr-hide");
             await game.dice3d.waitFor3DAnimationByMessageID(message.id);
         }
 
-        const content = $(html).find('.message-content');
-
-        if (content.length === 0) {
-            await $(html).removeClass("rsr-hide");
-            ui.chat.scrollBottom();
-            return;
-        }
+        let content = $(html).find('.message-content');
+        if (content.length === 0) content = $(html);
         
-        // This will force dual rolls on non-item messages, since this is the only place we can catch this before it is displayed.
         if (message.isAuthor && SettingsUtility.getSettingValue(SETTING_NAMES.ALWAYS_ROLL_MULTIROLL) && !ChatUtility.isMessageMultiRoll(message)) {
-            await _enforceDualRolls(message);
+            const newRolls = await _enforceDualRolls(message);
 
             if (message.flags[MODULE_SHORT].dual) {
                 ChatUtility.updateChatMessage(message, {
-                    flags: message.flags,
-                    rolls: message.rolls
+                    flags: message.flags
                 });
-
                 return;
             }
         }
@@ -106,7 +104,6 @@ export class ChatUtility {
         await _injectContent(message, type, content);
 
         if (SettingsUtility.getSettingValue(SETTING_NAMES.OVERLAY_BUTTONS_ENABLED)) {
-            // Setup hover buttons when the message is actually hovered(for optimisation).
             let hoverSetupComplete = false;
             content.hover(async () => {
                 if (!hoverSetupComplete) {
@@ -126,47 +123,129 @@ export class ChatUtility {
     }
 
     /**
-     * Updates a given chat message, saving changes to the database.
-     * @param {ChatMessage} message The chat message to update.
-     * @param {Object} update The object data for the message update.
+     * Process a usage (ACTIVITY) chat message after dnd5e's system.getHTML() has rewritten
+     * the card content. Called from the dnd5e.renderChatMessage hook, which fires at the
+     * end of ChatMessage5e.renderHTML() after system.getHTML() has stabilised the DOM.
+     *
+     * This is the correct injection point for usage cards in dnd5e 5.3.0. The
+     * renderChatMessageHTML hook fires too early — dnd5e overwrites the DOM immediately
+     * after it returns.
+     *
+     * @param {ChatMessage5e} message  The chat message being rendered.
+     * @param {HTMLElement}   html     The rendered message element (plain HTMLElement in V14).
      */
+    static async processUsageChatMessage(message, html) {
+        if (!message || !html) return;
+
+        const flags = message.flags?.[MODULE_SHORT];
+        if (!flags?.quickRoll || !flags?.processed) return;
+
+        const type = ChatUtility.getMessageType(message);
+        if (type !== ROLL_TYPE.ACTIVITY) return;
+
+        if (!message.isContentVisible) return;
+
+        const $html = html instanceof HTMLElement ? $(html) : html;
+
+        if (game.dice3d && game.dice3d.isEnabled() && message._dice3danimating) {
+            await $html.addClass("rsr-hide");
+            await game.dice3d.waitFor3DAnimationByMessageID(message.id);
+        }
+
+        let content = $html.find('.message-content');
+        if (content.length === 0) content = $html;
+
+        if (message.isAuthor && SettingsUtility.getSettingValue(SETTING_NAMES.ALWAYS_ROLL_MULTIROLL) && !ChatUtility.isMessageMultiRoll(message)) {
+            await _enforceDualRolls(message);
+
+            if (flags.dual) {
+                ChatUtility.updateChatMessage(message, { flags: message.flags });
+                return;
+            }
+        }
+
+        await _injectContent(message, type, content);
+
+        if (SettingsUtility.getSettingValue(SETTING_NAMES.OVERLAY_BUTTONS_ENABLED)) {
+            let hoverSetupComplete = false;
+            content.hover(async () => {
+                if (!hoverSetupComplete) {
+                    LogUtility.log("Injecting overlay hover buttons");
+                    hoverSetupComplete = true;
+                    await _injectOverlayButtons(message, content);
+                    _onOverlayHover(message, content);
+                }
+            });
+        }
+
+        await $html.removeClass("rsr-hide");
+        ui.chat.scrollBottom();
+    }
+
     static async updateChatMessage(message, update = {}, context = {}) {
         if (message instanceof ChatMessage) {
-            // FIX: Ensure Rolls are serialized to JSON before sending them to Foundry's database
             if (update.rolls && Array.isArray(update.rolls)) {
                 update.rolls = update.rolls.map(r => (r && typeof r.toJSON === "function") ? r.toJSON() : r);
             }
+            if (!update.flags) update.flags = message.flags;
             await message.update(update, context);
         }
     }
 
     static getMessageType(message) {
-        return message.flags.dnd5e?.messageType === MESSAGE_TYPE.USAGE 
-            ? ROLL_TYPE.ACTIVITY 
-            : message.flags.dnd5e?.messageType === MESSAGE_TYPE.ROLL 
-                ? (message.flags.dnd5e?.roll?.type ??  null)
-                : null;
+        const t = message.type;
+
+        // dnd5e 5.3.0: usage messages have type "usage" (plain string).
+        if (t === "usage" || t === "dnd5e.usage") return ROLL_TYPE.ACTIVITY;
+
+        // Roll messages use type "roll" and store the specific roll type in flags.
+        // message.system?.roll?.type is checked first as a future-proofing measure but
+        // dnd5e 5.3.0 does not register a system data model for "roll" typed messages,
+        // so flags.dnd5e.roll.type is the live path.
+        if (t === "roll" || t === "dnd5e.roll") {
+            return message.system?.roll?.type ?? message.flags?.dnd5e?.roll?.type ?? null;
+        }
+
+        // Legacy V12 fallbacks for messages created before dnd5e 4.x.
+        if (message.flags?.dnd5e?.messageType === MESSAGE_TYPE.USAGE || !!message.flags?.dnd5e?.use) return ROLL_TYPE.ACTIVITY;
+        if (message.flags?.dnd5e?.messageType === MESSAGE_TYPE.ROLL || !!message.flags?.dnd5e?.roll) {
+            return message.flags?.dnd5e?.roll?.type ?? null;
+        }
+        
+        return null;
     }
 
     static getActivityType(message) {
-        return message.flags.dnd5e?.activity.type;
+        // dnd5e 5.3.0: message.system.activity is a getter on UsageMessageData that calls
+        // getAssociatedActivity(), so both paths return the same activity object.
+        // flags.dnd5e.activity.type is the reliable stored path for all message versions.
+        return message.flags?.dnd5e?.activity?.type ?? message.system?.activity?.type;
     }
 
+    // dnd5e 5.3.0: getAssociatedActor() is now a native ChatMessage5e method. Use it as the
+    // primary path for actor resolution. The manual speaker fallback is kept for edge cases
+    // where the message is not a full ChatMessage5e instance (e.g. pre-create hooks).
     static getActorFromMessage(message) {
-        let actor = null;
-        if (message.speaker.token) {
-            const token = game.scenes.get(message.speaker.scene).tokens.get(message.speaker.token);
-            actor = token?.actor;
-        } else if (message.speaker.actor) {
-            actor = game.actors.get(message.speaker.actor);
+        if (typeof message.getAssociatedActor === "function") {
+            const actor = message.getAssociatedActor();
+            if (actor) return actor;
         }
 
-        return actor;
+        // Manual fallback using speaker data.
+        if (message.speaker?.token && message.speaker?.scene) {
+            const token = game.scenes.get(message.speaker.scene)?.tokens?.get(message.speaker.token);
+            if (token?.actor) return token.actor;
+        }
+        if (message.speaker?.actor) {
+            return game.actors.get(message.speaker.actor) ?? null;
+        }
+        return null;
     }
 
     static isMessageMultiRoll(message) {
+        const firstRoll = ChatUtility.getMessageRolls(message)[0];
         return (message.flags[MODULE_SHORT].advantage || message.flags[MODULE_SHORT].disadvantage || message.flags[MODULE_SHORT].dual
-            || (message.rolls[0] instanceof CONFIG.Dice.D20Roll && message.rolls[0].options.advantageMode !== CONFIG.Dice.D20Roll.ADV_MODE.NORMAL)) ?? false;
+            || (firstRoll && firstRoll.options?.advantageMode !== CONFIG.Dice.D20Roll.ADV_MODE.NORMAL)) ?? false;
     }
 
     static isMessageCritical(message) {
@@ -174,36 +253,19 @@ export class ChatUtility {
     }
 }
 
-/**
- * Handles hover begin events on the given html/jquery object.
- * @param {ChatMessage} message The chat message to process.
- * @param {JQuery} html The object to handle hover begin events for.
- * @private
- */
 function _onOverlayHover(message, html) {
     const hasPermission = game.user.isGM || message?.isAuthor;
-    const isItem =  message.flags.dnd5e?.use !== undefined;
+    const isItem = ChatUtility.getMessageType(message) === ROLL_TYPE.ACTIVITY;
 
     html.find('.rsr-overlay').show();
     html.find('.rsr-overlay-multiroll').toggle(hasPermission && !ChatUtility.isMessageMultiRoll(message));
     html.find('.rsr-overlay-crit').toggle(hasPermission && isItem && !ChatUtility.isMessageCritical(message));
 }
 
-/**
- * Handles hover end events on the given html/jquery object.
- * @param {JQuery} html The object to handle hover end events for.
- * @private
- */
 function _onOverlayHoverEnd(html) {
     html.find(".rsr-overlay").attr("style", "display: none;");
 }
 
-/**
- * Handles hover begin events on the given html/jquery object.
- * @param {ChatMessage} message The chat message to process.
- * @param {JQuery} html The object to handle hover begin events for.
- * @private
- */
 function _onTooltipHover(message, html) {
     const controlled = SettingsUtility._applyDamageToSelected && canvas?.tokens?.controlled?.length > 0;
     const targeted = SettingsUtility._applyDamageToTargeted && game?.user?.targets?.size > 0;
@@ -214,11 +276,6 @@ function _onTooltipHover(message, html) {
     }
 }
 
-/**
- * Handles hover end events on the given html/jquery object.
- * @param {JQuery} html The object to handle hover end events for.
- * @private
- */
 function _onTooltipHoverEnd(html) {
     html.find(".rsr-damage-buttons").attr("style", "display: none;height: 0px");
 }
@@ -236,12 +293,6 @@ function _onDamageHoverEnd(html) {
     html.find(".rsr-damage-buttons-xl").attr("style", "display: none;");
 }
 
-/**
- * Adds all manual action button event handlers to a chat card.
- * Note that the actual buttons are created during rendering and not added here.
- * @param {ChatMessage} message The chat message to process.
- * @param {JQuery} html The object to add button handlers to.
- */
 function _setupCardListeners(message, html) {
     if (SettingsUtility.getSettingValue(SETTING_NAMES.MANUAL_DAMAGE_MODE) > 0) {
         html.find('.card-buttons').find(`[data-action='rsr-${ROLL_TYPE.DAMAGE}']`).click(async event => {
@@ -265,35 +316,68 @@ function _setupCardListeners(message, html) {
 }
 
 function _processVanillaMessage(message) {
-    message.flags[MODULE_SHORT] = {};
-    message.flags[MODULE_SHORT].quickRoll = true;
-    message.flags[MODULE_SHORT].processed = true;
-    message.flags[MODULE_SHORT].useConfig = false;
+    if (typeof message.updateSource === "function") {
+        message.updateSource({
+            [`flags.${MODULE_SHORT}`]: {
+                quickRoll: true,
+                processed: true,
+                useConfig: false
+            }
+        });
+    } else {
+        message.flags[MODULE_SHORT] = {
+            quickRoll: true,
+            processed: true,
+            useConfig: false
+        };
+    }
 }
 
 async function _enforceDualRolls(message) {
     let dual = false;
-
-    for (let i = 0; i < message.rolls.length; i++) {
-        if (message.rolls[i] instanceof CONFIG.Dice.D20Roll) {
-            message.rolls[i] = await RollUtility.ensureMultiRoll(message.rolls[i]);
+    let newRolls = ChatUtility.getMessageRolls(message);
+    
+    for (let i = 0; i < newRolls.length; i++) {
+        if (newRolls[i] instanceof CONFIG.Dice.D20Roll || newRolls[i].class === "D20Roll") {
+            newRolls[i] = await RollUtility.ensureMultiRoll(newRolls[i]);
             dual = true;
         }
     }
-
+    
     message.flags[MODULE_SHORT].dual = dual;
+    message.flags[MODULE_SHORT].rolls = newRolls.map(r => r.toJSON ? r.toJSON() : r);
+    return newRolls;
+}
+
+function _safeInsert(sectionHTML, targetHTML) {
+    if (targetHTML.is('.message-content') || targetHTML.hasClass('chat-message') || targetHTML.length === 0) {
+        targetHTML.append(sectionHTML);
+    } else {
+        sectionHTML.insertBefore(targetHTML);
+    }
 }
 
 async function _injectContent(message, type, html) {
     LogUtility.log("Injecting content into chat message");
-    const parent = message.getOriginatingMessage();
+    
+    // dnd5e 5.3.0: getOriginatingMessage() is a native ChatMessage5e method that returns
+    // the usage card a roll message was spawned from, or `this` when no link exists.
+    // We only treat it as a real parent when it is a different message.
+    let parent = null;
+    if (typeof message.getOriginatingMessage === "function") {
+        const origin = message.getOriginatingMessage();
+        if (origin && origin !== message) parent = origin;
+    }
+    if (!parent && typeof message.getAssociatedMessage === "function") parent = message.getAssociatedMessage();
+    if (!parent && message.flags?.dnd5e?.originatingMessage) parent = game.messages.get(message.flags.dnd5e.originatingMessage);
+    if (!parent && message.system?.message) parent = game.messages.get(message.system.message);
+    
     message.flags[MODULE_SHORT].displayChallenge = parent?.shouldDisplayChallenge ?? message.shouldDisplayChallenge;
     message.flags[MODULE_SHORT].displayAttackResult = game.user.isGM || (game.settings.get("dnd5e", "attackRollVisibility") !== "none");
 
-    switch (type) {     
+    switch (type) {
         case ROLL_TYPE.DAMAGE:
-            // Handle damage enrichers
-            if (!message.flags.dnd5e?.item?.id) {
+            if (!message.flags?.dnd5e?.item?.id && !message.system?.item?.id) {
                 const enricher = html.find('.dice-roll');
                 
                 html.parent().find('.flavor-text').text('');
@@ -301,7 +385,9 @@ async function _injectContent(message, type, html) {
                 html.find('.chat-card').append(enricher);                        
 
                 message.flags[MODULE_SHORT].renderDamage = true;
-                message.flags[MODULE_SHORT].isCritical = message.rolls[0]?.isCritical;
+                
+                const mRolls = ChatUtility.getMessageRolls(message);
+                message.flags[MODULE_SHORT].isCritical = mRolls[0]?.isCritical;
 
                 await _injectDamageRoll(message, enricher);
 
@@ -311,31 +397,42 @@ async function _injectContent(message, type, html) {
                 enricher.remove();
                 break;
             }
+            // falls through to ATTACK when item id is present
         case ROLL_TYPE.ATTACK:
             if (parent && parent.flags[MODULE_SHORT] && message.isAuthor) {
+                parent.flags.dnd5e ??= {};
                 if (type === ROLL_TYPE.ATTACK) {
                     parent.flags[MODULE_SHORT].renderAttack = true;
-                    parent.flags.dnd5e.roll = message.flags.dnd5e?.roll;
-                    parent.flags.dnd5e.originatingMessage = parent.id;
-                    game.dnd5e.registry.messages.track(parent);
+                    // dnd5e 5.3.0: roll data lives in flags.dnd5e.roll; system.roll is
+                    // undefined since there is no data model for "roll" typed messages.
+                    parent.flags.dnd5e.roll = message.flags?.dnd5e?.roll ?? message.system?.roll;
+                    // dnd5e 5.3.0: do NOT set parent.flags.dnd5e.originatingMessage to
+                    // parent.id — that would make getOriginatingMessage() return the usage
+                    // card itself for all future lookups, breaking the registry. The
+                    // incoming roll message is deleted below, so there is no value in
+                    // registering it with the MessageRegistry either.
                 }
 
                 if (type === ROLL_TYPE.DAMAGE) {
                     parent.flags[MODULE_SHORT].renderDamage = true;
-                    parent.flags[MODULE_SHORT].isCritical = message.rolls[0]?.isCritical;
-                    parent.flags[MODULE_SHORT].isHealing = message.flags.dnd5e.activity.type === "heal";
+                    
+                    const mRolls = ChatUtility.getMessageRolls(message);
+                    parent.flags[MODULE_SHORT].isCritical = mRolls[0]?.isCritical;
+                    
+                    const actType = message.flags?.dnd5e?.activity?.type ?? message.system?.activity?.type;
+                    parent.flags[MODULE_SHORT].isHealing = actType === "heal";
                 }
-                
-                // if (game.dice3d && game.dice3d.isEnabled()) {
-                //     await CoreUtility.waitUntil(() => !message._dice3danimating);
-                // }
 
                 parent.flags[MODULE_SHORT].quickRoll = true;                
-                parent.rolls.push(...message.rolls);
+                
+                let newParentRolls = ChatUtility.getMessageRolls(parent);
+                let newMsgRolls = ChatUtility.getMessageRolls(message);
+                newParentRolls.push(...newMsgRolls);
+
+                parent.flags[MODULE_SHORT].rolls = newParentRolls.map(r => r.toJSON ? r.toJSON() : r);
 
                 ChatUtility.updateChatMessage(parent, {
                     flags: parent.flags,
-                    rolls: parent.rolls,
                     flavor: "vanilla",
                 });
 
@@ -349,13 +446,13 @@ async function _injectContent(message, type, html) {
         case ROLL_TYPE.ABILITY_TEST:
         case ROLL_TYPE.DEATH_SAVE:
         case ROLL_TYPE.TOOL:
-            if (!message.isContentVisible) {
-                return;
-            }
+            if (!message.isContentVisible) return;
 
-            const roll = message.rolls[0];
+            const roll = ChatUtility.getMessageRolls(message)[0];
+            if (!roll) return;
+            
             roll.options.displayChallenge = message.flags[MODULE_SHORT].displayChallenge;
-            roll.options.forceSuccess = message.flags.dnd5e?.roll?.forceSuccess;
+            roll.options.forceSuccess = message.flags?.dnd5e?.roll?.forceSuccess ?? message.system?.roll?.forceSuccess;
 
             const render = await RenderUtility.render(TEMPLATE.MULTIROLL, { roll, key: type })
             html.find('.dice-total').replaceWith(render);
@@ -367,17 +464,17 @@ async function _injectContent(message, type, html) {
             }
             break;
         case ROLL_TYPE.ACTIVITY:
-            if (!message.isContentVisible) {
-                return;
-            }
+            if (!message.isContentVisible) return;
 
-            const actions = html.find('.card-buttons');
+            let actions = html.find('.card-buttons');
+            if (actions.length === 0) actions = html.find('.card-activities');
+            if (actions.length === 0) actions = html.find('.dnd5e2.chat-card');
+            if (actions.length === 0) actions = html;
             
-            // Remove any redundant dice roll elements that were added forcefully by dnd5e system
             html.find('.dice-roll').remove();
 
             if (message.flags[MODULE_SHORT].renderAttack || message.flags[MODULE_SHORT].renderAttack === false) {
-                actions.find(`[data-action=rollAttack]`).remove();
+                html.find('[data-action=rollAttack], [data-action=attack]').remove();
                 await _injectAttackRoll(message, actions);
 
                 html.find('.rsr-section-attack').append(html.find('.supplement'));
@@ -385,8 +482,8 @@ async function _injectContent(message, type, html) {
             }
             
             if (message.flags[MODULE_SHORT].manualDamage || message.flags[MODULE_SHORT].renderDamage) {
-                actions.find(`[data-action=rollDamage]`).remove();
-                actions.find(`[data-action=rollHealing]`).remove();
+                html.find('[data-action=rollDamage], [data-action=damage]').remove();
+                html.find('[data-action=rollHealing], [data-action=heal]').remove();
             }
 
             if (message.flags[MODULE_SHORT].manualDamage) {
@@ -398,7 +495,7 @@ async function _injectContent(message, type, html) {
             }
 
             if (message.flags[MODULE_SHORT].renderFormula) {
-                actions.find(`[data-action=rollFormula]`).remove();
+                html.find('[data-action=rollFormula], [data-action=formula]').remove();
                 await _injectFormulaRoll(message, actions);
             }
 
@@ -406,41 +503,55 @@ async function _injectContent(message, type, html) {
                 await _injectApplyDamageButtons(message, html);
             }
 
-            // FIX: Remove both the extra sub-cards and the extra dice-roll containers
-            html.find('.dnd5e2.chat-card').not('.activation-card').remove();
-            html.closest('.message-content').find('> .dice-roll').remove(); 
+            html.find('.dnd5e2.chat-card').not('.activation-card, .usage-card').remove();
+            const rootParent = html.closest('.message-content');
+            if (rootParent.length) rootParent.find('> .dice-roll').remove(); 
             break;
         default:
             break;
     }
 
-    //_setupRerollDice(html);
     _setupCardListeners(message, html);
 }
 
 async function _injectAttackRoll(message, html) {
     const ChatMessage5e = CONFIG.ChatMessage.documentClass;
-    const roll = message.rolls.find(r => r instanceof CONFIG.Dice.D20Roll);
+    const rolls = ChatUtility.getMessageRolls(message);
+    
+    const roll = rolls.find(r => r instanceof CONFIG.Dice.D20Roll || r.class === "D20Roll" || r.constructor?.name === "D20Roll");
 
     if (!roll) return;
     
     RollUtility.resetRollGetters(roll);
 
     roll.options.displayChallenge = message.flags[MODULE_SHORT].displayAttackResult;
-    roll.options.hideFinalAttack = SettingsUtility.getSettingValue(SETTING_NAMES.HIDE_FINAL_RESULT_ENABLED) && !game.actors.get(message.speaker.actor)?.isOwner;
+
+    // dnd5e 5.3.0: Use getAssociatedActor() instead of game.actors.get(speaker.actor) so
+    // that token actors (which are not in game.actors) are correctly resolved. Previously
+    // this always returned null for unlinked tokens, causing hideFinalAttack to silently
+    // default to false for GMs viewing other players' rolls.
+    const actor = ChatUtility.getActorFromMessage(message);
+    roll.options.hideFinalAttack = SettingsUtility.getSettingValue(SETTING_NAMES.HIDE_FINAL_RESULT_ENABLED) && !actor?.isOwner;
 
     const render = await RenderUtility.render(TEMPLATE.MULTIROLL, { roll, key: ROLL_TYPE.ATTACK });
     const chatData = await roll.toMessage({}, { create: false });
-    const rollHTML = $(await new ChatMessage5e(chatData).renderHTML()).find('.dice-roll');    
+    // Foundry V14 removed CONST.CHAT_MESSAGE_TYPES entirely. The previous workaround of
+    // setting chatData.type to the numeric OOC value now coerces to the string "1", which
+    // fails ChatMessage5e's strict type validation and throws a DataModelValidationError
+    // before renderHTML() is ever reached. roll.toMessage() already sets type:"roll" which
+    // is a valid Foundry V14 type, so we leave it alone.
+
+    const rollHTML = $(await new ChatMessage5e(chatData).renderHTML()).find('.dice-roll');   
     rollHTML.find('.dice-total').replaceWith(render);
     rollHTML.find('.dice-tooltip').prepend(rollHTML.find('.dice-formula'));
 
     if (roll.options.hideFinalAttack) {
         rollHTML.find('.dice-tooltip').find('.tooltip-part.constant').remove();
         rollHTML.find('.dice-formula').text("1d20 + " + CoreUtility.localize(`${MODULE_SHORT}.chat.hide`));
-    }    
+    }   
 
-    const ammo = message.getAssociatedActor().items.get(message.flags[MODULE_SHORT].ammunition)?.name;
+    // dnd5e 5.3.0: getAssociatedActor() correctly resolves token actors.
+    const ammo = ChatUtility.getActorFromMessage(message)?.items?.get(message.flags[MODULE_SHORT].ammunition)?.name;
 
     const sectionHTML = $(await RenderUtility.render(TEMPLATE.SECTION,
     {
@@ -451,16 +562,20 @@ async function _injectAttackRoll(message, html) {
     }));
     
     $(sectionHTML).append(rollHTML);
-    sectionHTML.insertBefore(html);
+    _safeInsert(sectionHTML, html);
 }
 
 async function _injectFormulaRoll(message, html) {
     const ChatMessage5e = CONFIG.ChatMessage.documentClass;
-    const roll = message.rolls.find(r => r instanceof CONFIG.Dice.BasicRoll);
+    const rolls = ChatUtility.getMessageRolls(message);
+    
+    const roll = rolls.find(r => r instanceof CONFIG.Dice.BasicRoll || r.class === "BasicRoll" || r.constructor?.name === "BasicRoll");
 
     if (!roll) return;
 
     const chatData = await roll.toMessage({}, { create: false });
+    // Foundry V14: see comment in _injectAttackRoll. type:"roll" is set by toMessage().
+
     const rollHTML = $(await new ChatMessage5e(chatData).renderHTML()).find('.dice-roll');
     rollHTML.find('.dice-tooltip').prepend(rollHTML.find('.dice-formula'));
 
@@ -472,17 +587,18 @@ async function _injectFormulaRoll(message, html) {
     }));
     
     $(sectionHTML).append(rollHTML);
-    sectionHTML.insertBefore(html);
-
+    _safeInsert(sectionHTML, html);
 }
 
 async function _injectDamageRoll(message, html) {
     const ChatMessage5e = CONFIG.ChatMessage.documentClass;
-    const rolls = message.rolls.filter(r => r instanceof CONFIG.Dice.DamageRoll);
+    const rolls = ChatUtility.getMessageRolls(message).filter(r => r instanceof CONFIG.Dice.DamageRoll || r.class === "DamageRoll" || r.constructor?.name === "DamageRoll");
 
     if (!rolls || rolls.length === 0) return;
 
     const chatData = await CONFIG.Dice.DamageRoll.toMessage(rolls, {}, { create: false });
+    // Foundry V14: see comment in _injectAttackRoll. type:"roll" is set by toMessage().
+
     const rollHTML = $(await new ChatMessage5e(chatData).renderHTML()).find('.dice-roll');
     rollHTML.find('.dice-tooltip').prepend(rollHTML.find('.dice-formula'));
     rollHTML.find('.dice-result').addClass('rsr-damage');
@@ -504,7 +620,7 @@ async function _injectDamageRoll(message, html) {
     const sectionHTML = $(await RenderUtility.render(TEMPLATE.SECTION, header));
     
     $(sectionHTML).append(rollHTML);
-    sectionHTML.insertBefore(html);
+    _safeInsert(sectionHTML, html);
 }
 
 async function _injectDamageButton(message, html) {
@@ -542,12 +658,6 @@ async function _injectBreakConcentrationButton(message, html) {
     html.append($(render).addClass('rsr-concentration-buttons'));
 }
 
-/**
- * Adds buttons to a chat card for applying rolled damage/healing to tokens.
- * @param {ChatMessage} message The chat message for which content is being injected.
- * @param {JQuery} html The object to add overlay buttons to.
- * @private
- */
 async function _injectApplyDamageButtons(message, html) {
     const render = await RenderUtility.render(TEMPLATE.DAMAGE_BUTTONS, {});
 
@@ -565,7 +675,6 @@ async function _injectApplyDamageButtons(message, html) {
     total.append(renderXL);
 
     if (!SettingsUtility.getSettingValue(SETTING_NAMES.ALWAYS_SHOW_BUTTONS)) {
-        // Enable Hover Events (to show/hide the elements).
         tooltip.each((i, el) => {        
             $(el).find('.rsr-damage-buttons').attr("style", "display: none;height: 0px");
             $(el).hover(_onTooltipHover.bind(this, message, $(el)), _onTooltipHoverEnd.bind(this, $(el)));
@@ -576,34 +685,19 @@ async function _injectApplyDamageButtons(message, html) {
     }
 }
 
-/**
- * Adds all overlay buttons to a chat card.
- * @param {ChatMessage} message The chat message for which content is being injected.
- * @param {JQuery} html The object to add overlay buttons to.
- * @private
- */
 async function _injectOverlayButtons(message, html) {
     await _injectOverlayRetroButtons(message, html);
-    await _injectOverlayHeaderButtons(message, html);    
+    await _injectOverlayHeaderButtons(message, html);   
     
-    // Enable Hover Events (to show/hide the elements).
     _onOverlayHoverEnd(html);
     html.hover(_onOverlayHover.bind(this, message, html), _onOverlayHoverEnd.bind(this, html));
 }
 
-
-/**
- * Adds overlay buttons to a chat card for retroactively making a roll into a multi roll or a crit.
- * @param {ChatMessage} message The chat message for which content is being injected.
- * @param {JQuery} html The object to add overlay buttons to.
- * @private
- */
 async function _injectOverlayRetroButtons(message, html) {
     const overlayMultiRoll = await RenderUtility.render(TEMPLATE.OVERLAY_MULTIROLL, {});
 
     html.find('.rsr-multiroll .dice-total').append($(overlayMultiRoll));
 
-    // Handle clicking the multi-roll overlay buttons
     html.find(".rsr-overlay-multiroll div").click(async event => {
         await _processRetroAdvButtonEvent(message, event);
     });
@@ -612,28 +706,15 @@ async function _injectOverlayRetroButtons(message, html) {
 
     html.find('.rsr-damage .dice-total').append($(overlayCrit));
 
-    // Handle clicking the multi-roll overlay buttons
     html.find(".rsr-overlay-crit div").click(async event => {
         await _processRetroCritButtonEvent(message, event);
     });
 }
 
- /**
- * Adds overlay buttons to a chat card header for quick-repeating a roll.
- * @param {ChatMessage} message The chat message for which content is being injected.
- * @param {JQuery} html The object to add overlay buttons to.
- * @private
- */
- async function _injectOverlayHeaderButtons(message, html) {
+async function _injectOverlayHeaderButtons(message, html) {
 
- }
+}
 
-/**
- * Processes and handles a manual damage button click event.
- * @param {ChatMessage} message The chat message for which an event is being processed.
- * @param {Event} event The originating event of the button click.
- * @private
- */
 async function _processDamageButtonEvent(message, event) {
     event.preventDefault();
     event.stopPropagation();
@@ -656,12 +737,6 @@ async function _processBreakConcentrationButtonEvent(message, event) {
     }
 }
 
-/**
- * Processes and handles an apply damage/healing/temphp button click event.
- * @param {ChatMessage} message The chat message for which an event is being processed.
- * @param {Event} event The originating event of the button click.
- * @private
- */
 async function _processApplyButtonEvent(message, event) {
     event.preventDefault();
     event.stopPropagation();
@@ -671,15 +746,11 @@ async function _processApplyButtonEvent(message, event) {
     const multiplier = button.dataset.multiplier;
     const dice = $(button).closest('.tooltip-part').find('.dice');
 
-    if (action !== "rsr-apply-damage" && action !== "rsr-apply-temp") {
-        return;
-    }
+    if (action !== "rsr-apply-damage" && action !== "rsr-apply-temp") return;
 
     const targets = CoreUtility.getCurrentTargets();
 
-    if (targets.size === 0) {
-        return;
-    }
+    if (targets.size === 0) return;
 
     const isTempHP = action === "rsr-apply-temp";
     const damage = _getApplyDamage(message, dice, multiplier);
@@ -704,15 +775,11 @@ async function _processApplyTotalButtonEvent(message, event) {
     const action = button.dataset.action;
     const multiplier = Number(button.dataset.multiplier);
 
-    if (action !== "rsr-apply-damage" && action !== "rsr-apply-temp") {
-        return;
-    }
+    if (action !== "rsr-apply-damage" && action !== "rsr-apply-temp") return;
 
     const targets = CoreUtility.getCurrentTargets();
 
-    if (targets.size === 0) {
-        return;
-    }
+    if (targets.size === 0) return;
     
     const isTempHP = action === "rsr-apply-temp";
     const damages = [];
@@ -742,16 +809,11 @@ function _getApplyDamage(message, dice, multiplier) {
     const value = parseInt(total.find('.value').text());
     const type = total.find('.label').text().toLowerCase();
 
-    const properties = new Set(message.rolls.find(r => r instanceof CONFIG.Dice.DamageRoll)?.options?.properties ?? []);
+    const rolls = ChatUtility.getMessageRolls(message);
+    const properties = new Set(rolls.find(r => r instanceof CONFIG.Dice.DamageRoll || r.class === "DamageRoll")?.options?.properties ?? []);
     return { value: value, type: multiplier < 0 ? 'healing' : type, properties: properties };
 }
 
-/**
- * Processes and handles a retroactive advantage/disadvantage button click event.
- * @param {ChatMessage} message The chat message for which an event is being processed.
- * @param {Event} event The originating event of the button click.
- * @private
- */
 async function _processRetroAdvButtonEvent(message, event) {
     event.preventDefault();
     event.stopPropagation();
@@ -778,18 +840,24 @@ async function _processRetroAdvButtonEvent(message, event) {
         message.flags[MODULE_SHORT].advantage = state === ROLL_STATE.ADV;
         message.flags[MODULE_SHORT].disadvantage = state === ROLL_STATE.DIS;
 
-        const roll = message.rolls.find(r => r instanceof CONFIG.Dice.D20Roll);
-        await RollUtility.upgradeRoll(roll, state);
+        const originalRolls = ChatUtility.getMessageRolls(message);
+        const rollIndex = originalRolls.findIndex(r => r instanceof CONFIG.Dice.D20Roll || r.class === "D20Roll");
+        
+        if (rollIndex > -1) {
+            const upgradedRoll = await RollUtility.upgradeRoll(originalRolls[rollIndex], state);
+            if (upgradedRoll) originalRolls[rollIndex] = upgradedRoll;
+        }
 
-        if (key !== ROLL_TYPE.ATTACK && key !== ROLL_TYPE.TOOL_CHECK) {
-            message.flavor += message.rolls[0].hasAdvantage 
+        if (key !== ROLL_TYPE.ATTACK && key !== ROLL_TYPE.TOOL_CHECK && originalRolls[rollIndex]) {
+            message.flavor += originalRolls[rollIndex].hasAdvantage 
                 ? ` (${CoreUtility.localize("DND5E.Advantage")})` 
                 : ` (${CoreUtility.localize("DND5E.Disadvantage")})`;
         }
 
+        message.flags[MODULE_SHORT].rolls = originalRolls.map(r => r.toJSON ? r.toJSON() : r);
+
         ChatUtility.updateChatMessage(message, { 
             flags: message.flags,
-            rolls: message.rolls,
             flavor: message.flavor
         });
 
@@ -799,12 +867,6 @@ async function _processRetroAdvButtonEvent(message, event) {
     }
 }
 
-/**
- * Processes and handles a retroactive critical roll button click event.
- * @param {ChatMessage} message The chat message for which an event is being processed.
- * @param {Event} event The originating event of the button click.
- * @private
- */
 async function _processRetroCritButtonEvent(message, event) {
     event.preventDefault();
     event.stopPropagation();
@@ -827,13 +889,15 @@ async function _processRetroCritButtonEvent(message, event) {
         
         message.flags[MODULE_SHORT].isCritical = true;
 
-        const original = message.rolls;
+        const originalRolls = ChatUtility.getMessageRolls(message);
+        let newRolls = Array.from(originalRolls);
 
-        const rolls = message.rolls.filter(r => r instanceof CONFIG.Dice.DamageRoll);
+        const rolls = originalRolls.filter(r => r instanceof CONFIG.Dice.DamageRoll || r.class === "DamageRoll");
         const crits = await ActivityUtility.getDamageFromMessage(message);
 
+        // Retain original behavior for MIDI users if required
         if (CoreUtility.hasModule(MODULE_MIDI)) {
-            message.rolls = original;
+            newRolls = originalRolls;
         }
 
         for (let i = 0; i < rolls.length; i++) {
@@ -849,14 +913,15 @@ async function _processRetroCritButtonEvent(message, event) {
             }
 
             RollUtility.resetRollGetters(critRoll);
-            message.rolls[message.rolls.indexOf(baseRoll)] = critRoll;
+            newRolls[originalRolls.indexOf(baseRoll)] = critRoll;
         }
 
         await CoreUtility.tryRollDice3D(crits);
 
+        message.flags[MODULE_SHORT].rolls = newRolls.map(r => r.toJSON ? r.toJSON() : r);
+
         ChatUtility.updateChatMessage(message, {
-            flags: message.flags,
-            rolls: message.rolls
+            flags: message.flags
         });
 
         if (!game.dice3d || !game.dice3d.isEnabled()) {

--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -406,7 +406,9 @@ async function _injectContent(message, type, html) {
                 await _injectApplyDamageButtons(message, html);
             }
 
+            // FIX: Remove both the extra sub-cards and the extra dice-roll containers
             html.find('.dnd5e2.chat-card').not('.activation-card').remove();
+            html.closest('.message-content').find('> .dice-roll').remove(); 
             break;
         default:
             break;

--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -48,21 +48,27 @@ export class ChatUtility {
 
         const type = ChatUtility.getMessageType(message);
 
-        // Hide the message if we haven't yet finished processing RSR content
+       // Hide the message if we haven't yet finished processing RSR content
         if (!message.flags[MODULE_SHORT].processed) {
             await $(html).addClass("rsr-hide");
 
             if (type == ROLL_TYPE.ACTIVITY && message.isAuthor)
             {
+                // FIX: MUTEX LOCK to prevent AC5e from causing concurrent re-rolls
+                if (message._rsrIsProcessing) return;
+                message._rsrIsProcessing = true;
+
                 if (CoreUtility.hasModule(MODULE_MIDI)) {
                     const activityType = ChatUtility.getActivityType(message);
                     if (activityType == ROLL_TYPE.ATTACK || (activityType == ROLL_TYPE.ABILITY_SAVE && message.flags[MODULE_SHORT].renderDamage)) {
                         message.flags[MODULE_SHORT].processed = true;
                     } else {
-                        ActivityUtility.runActivityActions(message);
+                        // FIX: Added missing await
+                        await ActivityUtility.runActivityActions(message);
                     }  
                 } else {
-                    ActivityUtility.runActivityActions(message);
+                    // FIX: Added missing await
+                    await ActivityUtility.runActivityActions(message);
                 }                
             }
 
@@ -126,6 +132,10 @@ export class ChatUtility {
      */
     static async updateChatMessage(message, update = {}, context = {}) {
         if (message instanceof ChatMessage) {
+            // FIX: Ensure Rolls are serialized to JSON before sending them to Foundry's database
+            if (update.rolls && Array.isArray(update.rolls)) {
+                update.rolls = update.rolls.map(r => (r && typeof r.toJSON === "function") ? r.toJSON() : r);
+            }
             await message.update(update, context);
         }
     }

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -2,7 +2,6 @@ import { splitTypedBonusDamage } from "./typed-bonus-split.js";
 import { BonusManager } from "./bonus.js";
 import { RerollManager } from "./reroll.js";
 import { MODULE_SHORT, MODULE_TITLE } from "../module/const.js";
-import { MODULE_AA } from "../module/integration.js";
 import { ActivityUtility } from "./activity.js";
 import { ChatUtility } from "./chat.js";
 import { CoreUtility } from "./core.js";
@@ -10,10 +9,7 @@ import { LogUtility } from "./log.js";
 import { ROLL_TYPE, RollUtility } from "./roll.js";
 import { SETTING_NAMES, SettingsUtility } from "./settings.js";
 
-export const HOOKS_CORE = {
-    INIT: "init",
-    READY: "ready"
-}
+export const HOOKS_CORE = { INIT: "init", READY: "ready" }
 
 export const HOOKS_DND5E = {
     PRE_ROLL_ABILITY_CHECK: "dnd5e.preRollAbilityCheckV2",
@@ -23,35 +19,24 @@ export const HOOKS_DND5E = {
     PRE_ROLL_ATTACK: "dnd5e.preRollAttackV2",
     PRE_ROLL_DAMAGE: "dnd5e.preRollDamageV2",
     PRE_USE_ACTIVITY: "dnd5e.preUseActivity",
-    POST_USE_ACTIVITY: "dnd5e.postUseActivity",
+    // POST_USE_ACTIVITY removed: in dnd5e 5.3.0 we use usageConfig.subsequentActions = false
+    // in PRE_USE_ACTIVITY instead of returning false from POST_USE_ACTIVITY to block auto-rolls.
     ACTIVITY_CONSUMPTION: "dnd5e.activityConsumption",
     DISPLAY_CARD: "dnd5e.displayCard",
-    RENDER_CHAT_MESSAGE: "dnd5e.renderChatMessage",    
+    RENDER_CHAT_MESSAGE: "dnd5e.renderChatMessage",
     RENDER_ITEM_SHEET: "renderItemSheet5e",
     RENDER_ACTOR_SHEET: "renderActorSheet5e",
 }
 
-export const HOOKS_INTEGRATION = {
-    DSN_ROLL_COMPLETE: "diceSoNiceRollComplete"
-}
+export const HOOKS_INTEGRATION = { DSN_ROLL_COMPLETE: "diceSoNiceRollComplete" }
 
-/**
- * Utility class to handle registering listeners for hooks needed throughout the module.
- */
 export class HooksUtility {
-    /**
-     * Register all necessary hooks for the module as a whole.
-     */
     static registerModuleHooks() {
         Hooks.once(HOOKS_CORE.INIT, () => {
             LogUtility.log(`Initialising ${MODULE_TITLE}`);
-            
             SettingsUtility.registerSettings();
-
             HooksUtility.registerRollHooks();
             HooksUtility.registerChatHooks();
-            
-            // Addon: Initialize Reroll feature
             RerollManager.registerGlobalListener();
         });
 
@@ -61,42 +46,33 @@ export class HooksUtility {
                 Object.fromEntries(Object.entries(CONFIG.DND5E.healingTypes).map(([k, v]) => [k, v.label])),
                 { recursive: false }
             );
-            
             CONFIG.DND5E.aggregateDamageDisplay = SettingsUtility.getSettingValue(SETTING_NAMES.AGGREGATE_DAMAGE) ?? true;
-
-            HooksUtility.registerSheetHooks();
-            HooksUtility.registerIntegrationHooks();
-            
             LogUtility.log(`Loaded ${MODULE_TITLE}`);
         });
     }
 
-    /**
-     * Register roll specific hooks for module functionality.
-     */
     static registerRollHooks() {
         LogUtility.log("Registering roll hooks");
 
-        if (SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_ABILITY_ENABLED)) { 
+        if (SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_ABILITY_ENABLED)) {
             Hooks.on(HOOKS_DND5E.PRE_ROLL_ABILITY_CHECK, (config, dialog, message) => {
                 RollUtility.processRoll(config, dialog, message);
                 return true;
             });
-
             Hooks.on(HOOKS_DND5E.PRE_ROLL_SAVING_THROW, (config, dialog, message) => {
                 RollUtility.processRoll(config, dialog, message);
                 return true;
             });
         }
 
-        if (SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_SKILL_ENABLED)) { 
+        if (SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_SKILL_ENABLED)) {
             Hooks.on(HOOKS_DND5E.PRE_ROLL_SKILL, (config, dialog, message) => {
                 RollUtility.processRoll(config, dialog, message);
                 return true;
             });
         }
 
-        if (SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_TOOL_ENABLED)) { 
+        if (SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_TOOL_ENABLED)) {
             Hooks.on(HOOKS_DND5E.PRE_ROLL_TOOL_CHECK, (config, dialog, message) => {
                 RollUtility.processRoll(config, dialog, message);
                 return true;
@@ -104,73 +80,129 @@ export class HooksUtility {
         }
 
         if (SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_ACTIVITY_ENABLED)) {
+            // dnd5e 5.3.0: Set subsequentActions = false to prevent the system from
+            // auto-triggering attack/damage rolls after item use. RSR handles those itself
+            // via preCreateChatMessage + ActivityUtility.runActivityActions(). This replaces
+            // the old setTimeout/postUseActivity hack that returned false to block auto-rolls,
+            // which broke entirely in 5.3.0 because postUseActivity now only gates the
+            // _triggerSubsequentActions call (line 16848 in dnd5e.mjs), not message creation.
             Hooks.on(HOOKS_DND5E.PRE_USE_ACTIVITY, (activity, usageConfig, dialogConfig, messageConfig) => {
-                RollUtility.processActivity(usageConfig, dialogConfig, messageConfig);
-                ActivityUtility.setRenderFlags(activity, messageConfig);
+                if (!SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_VANILLA_ENABLED)) {
+                    dialogConfig.configure = false;
+                    usageConfig.subsequentActions = false;
+                }
                 return true;
             });
 
-            Hooks.on(HOOKS_DND5E.PRE_ROLL_ATTACK, (config, dialog, message) => {                
-                if (!message.data?.flags || !message.data.flags[MODULE_SHORT]?.quickRoll) return true;
+            Hooks.on(HOOKS_DND5E.PRE_ROLL_ATTACK, (config, dialog, message) => {
+                const flags = message?.flags || message?.data?.flags;
+                if (!flags || !flags[MODULE_SHORT]?.quickRoll) return true;
 
                 for (const roll of config.rolls) {
                     roll.options.advantage ??= config.advantage;
-                    roll.options.disadvantage ??= config.disadvantage; 
+                    roll.options.disadvantage ??= config.disadvantage;
                 }
-
                 dialog.configure = false;
-
                 return true;
             });
 
             Hooks.on(HOOKS_DND5E.PRE_ROLL_DAMAGE, (config, dialog, message) => {
-                if (!message.data?.flags || !message.data.flags[MODULE_SHORT]?.quickRoll) return true;
+                const flags = message?.flags || message?.data?.flags;
+                if (!flags || !flags[MODULE_SHORT]?.quickRoll) return true;
 
-                for ( const roll of config.rolls ) {
+                for (const roll of config.rolls) {
                     roll.options ??= {};
                     roll.options.isCritical ??= config.isCritical;
                 }
-        
                 dialog.configure = false;
-
                 return true;
-            });           
+            });
 
+            // dnd5e 5.3.0: ActivityUsageUpdates always uses `updates.item` (an array of
+            // { _id, ...dotNotationProperties } objects). The `updates.items` key from older
+            // versions no longer exists and has been removed from this hook.
             Hooks.on(HOOKS_DND5E.ACTIVITY_CONSUMPTION, (activity, usageConfig, messageConfig, updates) => {
-                if (activity.hasOwnProperty(ROLL_TYPE.ATTACK) && updates.item.length > 0 && messageConfig.data) {
-                    const ammo = updates.item.find(i => i["system.quantity"]);
+                const hasAttack = activity.type === "attack" || !!activity.attack || activity.hasOwnProperty(ROLL_TYPE.ATTACK);
+                const items = updates.item;
+
+                if (hasAttack && items && items.length > 0) {
+                    const ammo = items.find(i => i["system.quantity"] !== undefined || i["system.uses.spent"] !== undefined);
                     if (!ammo) return;
-                    messageConfig.data.flags[MODULE_SHORT].ammunition = ammo._id;
-                    ammo["system.quantity"]++;
+
+                    messageConfig.flags ??= {};
+                    messageConfig.flags[MODULE_SHORT] ??= {};
+                    messageConfig.flags[MODULE_SHORT].ammunition = ammo._id;
+
+                    // Temporarily restore the quantity so the attack roll can access live ammo
+                    // data. The system will apply its own decrement after consumption.
+                    if (ammo["system.quantity"] !== undefined) ammo["system.quantity"]++;
                 }
             });
-            
-            // Ensures that the post use hook from RSR registers last so that it doesn't block other modules
-            setTimeout(() => {
-                Hooks.on(HOOKS_DND5E.POST_USE_ACTIVITY, (activity, usageConfig, results) => {
-                    return false;
-                });
-            }, 15000);
         }
     }
 
-    /**
-     * Register chat specific hooks for module functionality.
-     */
     static registerChatHooks() {
         LogUtility.log("Registering chat hooks");
 
-        // Modern V12/V13 hook for chat rendering
+        Hooks.on("preCreateChatMessage", (message, data, options, userId) => {
+            if (userId !== game.user.id) return;
+
+            const t = message.type;
+            // dnd5e 5.3.0: Usage cards are typed as "usage" (plain string, set in
+            // Activity#_createUsageMessage). The "dnd5e.usage" variant and the
+            // flags.dnd5e.use / flags.dnd5e.messageType === "usage" checks are kept as
+            // fallbacks for messages created by older dnd5e versions that may still exist
+            // in a world's chat history or be produced by other modules.
+            const isUsage = t === "usage"
+                || t === "dnd5e.usage"
+                || (!t && (message.flags?.dnd5e?.messageType === "usage" || !!message.flags?.dnd5e?.use));
+
+            if (isUsage && SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_ACTIVITY_ENABLED)) {
+                const quickVanilla = SettingsUtility.getSettingValue(SETTING_NAMES.QUICK_VANILLA_ENABLED);
+                if (quickVanilla) return;
+
+                const flags = message.flags[MODULE_SHORT] || {};
+                flags.quickRoll = true;
+                flags.processed = false;
+
+                const activity = ActivityUtility._getActivityFromMessage(message);
+
+                if (activity) {
+                    const hasAttack = activity.type === "attack" || !!activity.attack || activity.hasOwnProperty("attack");
+                    const hasDamage = activity.type === "damage" || !!activity.damage || activity.type === "attack" || activity.type === "save" || activity.hasOwnProperty("damage");
+                    const hasHealing = activity.type === "heal" || !!activity.healing || activity.hasOwnProperty("healing");
+                    const hasFormula = activity.type === "utility" || !!activity.roll || activity.hasOwnProperty("formula");
+
+                    if (hasAttack) flags.renderAttack = true;
+
+                    const manualDamageMode = SettingsUtility.getSettingValue(SETTING_NAMES.MANUAL_DAMAGE_MODE);
+                    if (hasDamage) {
+                        flags.manualDamage = (manualDamageMode === 2 || (manualDamageMode === 1 && hasAttack));
+                        flags.renderDamage = !flags.manualDamage;
+                    }
+
+                    if (hasHealing) {
+                        flags.isHealing = true;
+                        flags.renderDamage = true;
+                    }
+
+                    if (hasFormula) {
+                        flags.renderFormula = true;
+                        const fName = activity.roll?.name || activity.formula?.name;
+                        if (fName && fName !== "") flags.formulaName = fName;
+                    }
+                } else {
+                    LogUtility.logError("RSR: Could not resolve activity during preCreate.");
+                }
+
+                message.updateSource({ [`flags.${MODULE_SHORT}`]: flags });
+            }
+        });
+
         Hooks.on("renderChatMessageHTML", (message, html) => {
             const $html = html instanceof HTMLElement ? $(html) : html;
-            
-            // RSR Core Processing
             ChatUtility.processChatMessage(message, html);
-            
-            // Addon: Typed Bonus Split
             splitTypedBonusDamage(message, html);
-
-            // Addon: Bonus Manager Observer
             BonusManager.init(message, $html);
             if (html instanceof HTMLElement || html[0] instanceof HTMLElement) {
                 const element = html instanceof HTMLElement ? html : html[0];
@@ -182,16 +214,16 @@ export class HooksUtility {
                 $html.find('.dice-tooltip .dice-rolls .roll.die').addClass('rsr-ready');
             }
         });
+
+        // dnd5e 5.3.0: For usage (activity) messages, ChatMessage5e.renderHTML() calls
+        // system.getHTML() after the renderChatMessageHTML hook, which completely replaces
+        // .message-content innerHTML. RSR's injection for activity cards must therefore
+        // happen here, after system.getHTML() has finished rewriting the DOM.
+        Hooks.on(HOOKS_DND5E.RENDER_CHAT_MESSAGE, (message, html) => {
+            ChatUtility.processUsageChatMessage(message, html);
+        });
     }
 
-    /**
-     * Register sheet specific hooks for module functionality.
-     */
-    static registerSheetHooks() {
-        LogUtility.log("Registering sheet hooks");
-    }
-
-    static registerIntegrationHooks() {
-        LogUtility.log("Registering integration hooks");
-    }
+    static registerSheetHooks() {}
+    static registerIntegrationHooks() {}
 }

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -1,3 +1,6 @@
+import { splitTypedBonusDamage } from "./typed-bonus-split.js";
+import { BonusManager } from "./bonus.js";
+import { RerollManager } from "./reroll.js";
 import { MODULE_SHORT, MODULE_TITLE } from "../module/const.js";
 import { MODULE_AA } from "../module/integration.js";
 import { ActivityUtility } from "./activity.js";
@@ -47,6 +50,9 @@ export class HooksUtility {
 
             HooksUtility.registerRollHooks();
             HooksUtility.registerChatHooks();
+            
+            // Addon: Initialize Reroll feature
+            RerollManager.registerGlobalListener();
         });
 
         Hooks.on(HOOKS_CORE.READY, () => {
@@ -60,7 +66,7 @@ export class HooksUtility {
 
             HooksUtility.registerSheetHooks();
             HooksUtility.registerIntegrationHooks();
-
+            
             LogUtility.log(`Loaded ${MODULE_TITLE}`);
         });
     }
@@ -154,8 +160,27 @@ export class HooksUtility {
     static registerChatHooks() {
         LogUtility.log("Registering chat hooks");
 
-        Hooks.on(HOOKS_DND5E.RENDER_CHAT_MESSAGE, (message, html) => {
+        // Modern V12/V13 hook for chat rendering
+        Hooks.on("renderChatMessageHTML", (message, html) => {
+            const $html = html instanceof HTMLElement ? $(html) : html;
+            
+            // RSR Core Processing
             ChatUtility.processChatMessage(message, html);
+            
+            // Addon: Typed Bonus Split
+            splitTypedBonusDamage(message, html);
+
+            // Addon: Bonus Manager Observer
+            BonusManager.init(message, $html);
+            if (html instanceof HTMLElement || html[0] instanceof HTMLElement) {
+                const element = html instanceof HTMLElement ? html : html[0];
+                const observer = new MutationObserver(() => BonusManager.init(message, $(element)));
+                observer.observe(element, { childList: true, subtree: true });
+                setTimeout(() => observer.disconnect(), 15000);
+            }
+            if ($html.find('.dice-tooltip .dice-rolls .roll.die').length > 0) {
+                $html.find('.dice-tooltip .dice-rolls .roll.die').addClass('rsr-ready');
+            }
         });
     }
 

--- a/src/utils/reroll.js
+++ b/src/utils/reroll.js
@@ -1,4 +1,5 @@
 import { MODULE_SHORT } from "../module/const.js";
+import { ChatUtility } from "./chat.js";
 import { ROLL_TYPE } from "./roll.js";
 import { SETTING_NAMES, SettingsUtility } from "./settings.js";
 
@@ -7,8 +8,8 @@ import { SETTING_NAMES, SettingsUtility } from "./settings.js";
  */
 export class RerollManager {
     static registerGlobalListener() {
-        // Listen for clicks on the document to catch dice result interactions
-        $(document).on("mousedown", ".dice-tooltip .dice-rolls .roll.die", (event) => {
+        // FIX: Broadened the selector from '.roll.die' to '.roll' to catch 5e damage dice templates
+        $(document).on("mousedown", ".dice-tooltip .dice-rolls .roll", (event) => {
             if (!SettingsUtility.getSettingValue(SETTING_NAMES.REROLL_EVERYONE)) return;
             
             const dieElement = $(event.currentTarget);
@@ -18,13 +19,10 @@ export class RerollManager {
 
             if (!message) return;
 
-            // Handle Right-Click (GM Fudge)
             if (event.button === 2) {
                 if (!game.user.isGM || !SettingsUtility.getSettingValue(SETTING_NAMES.FUDGE_GM)) return;
                 this._handleFudge(message, dieElement);
-            } 
-            // Handle Left-Click (Player/Author Reroll)
-            else if (event.button === 0) {
+            } else if (event.button === 0) {
                 const canReroll = game.user.isGM || 
                                  (message.isAuthor && SettingsUtility.getSettingValue(SETTING_NAMES.REROLL_PLAYERS));
                 if (!canReroll) return;
@@ -35,81 +33,97 @@ export class RerollManager {
 
     static async _handleReroll(message, dieElement) {
         const { rollIndex, termIndex, resultIndex } = this._getDiePath(dieElement);
-        const rolls = [...message.rolls];
+
+        const rolls = ChatUtility.getMessageRolls(message).map(r => {
+            return r instanceof Roll ? r : Roll.fromData(r);
+        });
+
         const targetRoll = rolls[rollIndex];
-        const targetTerm = targetRoll.terms[termIndex];
+        if (!targetRoll) {
+            console.warn(`RSR | _handleReroll: no roll at index ${rollIndex}`, rolls);
+            return;
+        }
+
+        // FIX: Map to .dice instead of .terms to align with the rendered tooltip-parts
+        const targetTerm = targetRoll.dice[termIndex];
+        if (!targetTerm) {
+            console.warn(`RSR | _handleReroll: no dice term at index ${termIndex}`, targetRoll.dice);
+            return;
+        }
         
-        // Create a new roll for just one die
         const newDieRoll = await new Roll(`1d${targetTerm.faces}`).evaluate();
         const newResult = newDieRoll.dice[0].results[0];
         
-        // Update the original result
         targetTerm.results[resultIndex].result = newResult.result;
-        
-        // Re-evaluate modifiers (Advantage/Disadvantage highlighting)
         this._recalculateModifiers(targetTerm);
-
-        // Force Foundry to re-evaluate the total
         targetRoll._total = targetRoll._evaluateTotal();
-        
-        await message.update({ rolls: rolls });
+
+        _persistRolls(message, rolls);
         ui.notifications.info(`Rerolled die: New result is ${newResult.result}`);
     }
 
     static async _handleFudge(message, dieElement) {
         const { rollIndex, termIndex, resultIndex } = this._getDiePath(dieElement);
-        
-        new Dialog({
-            title: "Fudge Die Result",
-            content: `<input type="number" id="fudge-value" placeholder="Enter new value" autofocus>`,
-            buttons: {
-                fudge: {
-                    label: "Fudge It",
-                    callback: async (html) => {
-                        const newVal = parseInt(html.find("#fudge-value").val());
-                        if (isNaN(newVal)) return;
 
-                        const rolls = [...message.rolls];
-                        const targetRoll = rolls[rollIndex];
-                        const targetTerm = targetRoll.terms[termIndex];
+        const content = `<div style="padding:4px 0">
+            <input type="number" id="fudge-value" placeholder="Enter new value" autofocus
+                   style="width:100%; text-align:center; font-size:1.2em;">
+        </div>`;
 
-                        targetTerm.results[resultIndex].result = newVal;
-                        
-                        // Re-evaluate modifiers (Advantage/Disadvantage highlighting)
-                        this._recalculateModifiers(targetTerm);
-
-                        targetRoll._total = targetRoll._evaluateTotal();
-
-                        await message.update({ rolls: rolls });
-                    }
+        const newVal = await foundry.applications.api.DialogV2.prompt({
+            window: { title: "Fudge Die Result" },
+            content,
+            ok: {
+                label: "Fudge It",
+                callback: (event, button) => {
+                    const val = parseInt(button.form.elements["fudge-value"]?.value
+                        ?? button.form.querySelector("#fudge-value")?.value);
+                    return isNaN(val) ? null : val;
                 }
             }
-        }).render(true);
+        });
+
+        if (newVal === null || newVal === undefined) return;
+
+        const rolls = ChatUtility.getMessageRolls(message).map(r => {
+            return r instanceof Roll ? r : Roll.fromData(r);
+        });
+
+        const targetRoll = rolls[rollIndex];
+        if (!targetRoll) {
+            console.warn(`RSR | _handleFudge: no roll at index ${rollIndex}`, rolls);
+            return;
+        }
+
+        // FIX: Map to .dice instead of .terms to align with the rendered tooltip-parts
+        const targetTerm = targetRoll.dice[termIndex];
+        if (!targetTerm) {
+            console.warn(`RSR | _handleFudge: no dice term at index ${termIndex}`, targetRoll.dice);
+            return;
+        }
+
+        targetTerm.results[resultIndex].result = newVal;
+        this._recalculateModifiers(targetTerm);
+        targetRoll._total = targetRoll._evaluateTotal();
+
+        _persistRolls(message, rolls);
     }
 
-    /**
-     * Resets die result states and re-runs Advantage/Disadvantage logic.
-     * @private
-     */
     static _recalculateModifiers(targetTerm) {
         if (targetTerm.modifiers.some(m => m.includes("kh") || m.includes("kl"))) {
-            // Reset states so Foundry can re-determine which to discard
             targetTerm.results.forEach(r => {
                 r.discarded = false;
                 r.active = true;
             });
-            // Foundry internal method to re-apply "Keep Highest/Lowest" logic
             targetTerm._evaluateModifiers();
         }
     }
 
     static _getDiePath(dieElement) {
-        // Find the index of the tool-tip part (e.g., separate entries for d20 and constant bonuses)
         const tooltipPart = dieElement.closest(".tooltip-part");
         const allParts = dieElement.closest(".dice-tooltip").find(".tooltip-part");
         const termIndex = allParts.index(tooltipPart);
 
-        // Find the index of the roll (usually 0 for RSR, but helps if multiple rolls exist)
         const diceRoll = dieElement.closest(".dice-roll");
         const allDiceRolls = dieElement.closest(".message-content").find(".dice-roll");
         const rollIndex = Math.max(0, allDiceRolls.index(diceRoll));
@@ -117,5 +131,16 @@ export class RerollManager {
         const resultIndex = dieElement.index();
 
         return { rollIndex, termIndex, resultIndex };
+    }
+}
+
+function _persistRolls(message, rolls) {
+    const serialised = rolls.map(r => r.toJSON ? r.toJSON() : r);
+
+    if (message.flags?.[MODULE_SHORT]) {
+        message.flags[MODULE_SHORT].rolls = serialised;
+        ChatUtility.updateChatMessage(message, { flags: message.flags });
+    } else {
+        message.update({ rolls: serialised });
     }
 }

--- a/src/utils/reroll.js
+++ b/src/utils/reroll.js
@@ -1,0 +1,550 @@
+import { RerollManager } from "./reroll.js";
+
+// Import V2 API
+const { ApplicationV2 } = foundry.applications.api;
+
+export class BonusManager {
+    static init(message, html) {
+        const $html = html instanceof HTMLElement ? $(html) : html;
+
+        if (!message.isAuthor && !game.user.isGM) return false;
+        if (!$html || $html.length === 0) return false;
+
+        $html.find('.rsr-damage-buttons button, .rsr-damage-buttons-xl button')
+            .off('click.rsrFix')
+            .on('click.rsrFix', (ev) => {
+                ev.stopPropagation();
+            });
+
+        // --- DETECT SECTIONS ---
+        const hasAttackSection = $html.find('.rsr-section-attack').length > 0;
+        const hasDamageSection = $html.find('.rsr-section-damage').length > 0;
+
+        const isDnd5eRoll = !!message.flags.dnd5e?.roll?.type;
+        const isInitiative = message.flags.core?.initiativeRoll || 
+                             (message.flavor && message.flavor.includes("Initiative")) ||
+                             $html.find('.dice-flavor').text().includes("Initiative");
+
+        if (!hasAttackSection && !hasDamageSection && !isDnd5eRoll && !isInitiative) return false;
+
+        let injected = false;
+
+        // --- INJECT BUTTONS ---
+        if (hasAttackSection) {
+            this.injectButton(message, $html, "attack", ".rsr-section-attack");
+            injected = true;
+        }
+        
+        if (hasDamageSection) {
+            this.injectButton(message, $html, "damage", ".rsr-section-damage");
+            injected = true;
+        }
+
+        let rollType = null;
+        if (isInitiative) rollType = "initiative";
+        else if (isDnd5eRoll) rollType = message.flags.dnd5e.roll.type;
+
+        const validTypes = ["skill", "tool", "ability", "save", "death", "concentration", "initiative"];
+
+        if (rollType && validTypes.includes(rollType)) {
+            const label = rollType === "ability" ? "check" : rollType;
+            this.injectButton(message, $html, label, ".message-header");
+            injected = true;
+        }
+
+        return injected;
+    }
+
+    static injectButton(message, html, type, sectionSelector) {
+        const section = html.find(sectionSelector);
+        if (section.length === 0) return;
+
+        if (section.find(`.rsr-addon-bonus-btn[data-type="${type}"]`).length > 0) return;
+
+        let container = section.find('.rsr-header .rsr-title').first();
+        if (container.length === 0) container = section.find('.rsr-header').first();
+        if (container.length === 0) container = section.find('.message-sender').first(); 
+        if (container.length === 0) container = section; 
+
+        const titleType = type.charAt(0).toUpperCase() + type.slice(1);
+        const btn = $(`<i class="fas fa-plus-circle rsr-addon-bonus-btn" data-type="${type}" title="Add Bonus to ${titleType}"></i>`);
+        
+        if (sectionSelector === ".message-header") {
+            btn.css({ "margin-left": "8px", "align-self": "center", "font-size": "1.2em", "order": "10", "cursor": "pointer" });
+            section.append(btn);
+        } else {
+            container.append(btn);
+        }
+        
+        btn.click((ev) => {
+            ev.preventDefault();
+            ev.stopPropagation(); 
+            this.openBonusDialog(message, type);
+        });
+    }
+
+    static async openBonusDialog(message, type) {
+        let actor = null;
+        if (message.speaker.token) {
+            const token = game.scenes.get(message.speaker.scene)?.tokens.get(message.speaker.token);
+            actor = token?.actor;
+        } else if (message.speaker.actor) {
+            actor = game.actors.get(message.speaker.actor);
+        }
+
+        if (!actor) return ui.notifications.warn("No actor found for this message.");
+        
+        const rollData = actor.getRollData();
+        const bonuses = [];
+
+        // --- Auto-Detect if the original roll was a Crit ---
+        let isOriginalCrit = false;
+        if (type === "damage") {
+            const dmgRoll = message.rolls.find(r => r instanceof CONFIG.Dice.DamageRoll || r.options?.critical !== undefined);
+            if (dmgRoll) {
+                isOriginalCrit = dmgRoll.options?.critical === true || 
+                                 dmgRoll.options?.isCritical === true || 
+                                 message.flags?.dnd5e?.roll?.isCritical === true;
+            }
+        }
+
+        // --- 1. COLLECT CANDIDATE EFFECTS (Active Effects Only) ---
+        const candidateEffects = [];
+        const actorEffects = actor.appliedEffects || actor.effects; 
+        
+        actorEffects.forEach(e => {
+            if (!e.disabled && !e.isSuppressed) {
+                candidateEffects.push({ effect: e, source: "Actor" });
+            }
+        });
+
+        // --- 2. PROCESS EFFECTS ---
+        for (const entry of candidateEffects) {
+            const effect = entry.effect;
+            const changes = effect.changes.filter(c => c.key.trim() === "flags.rsr5e-addon.bonus");
+            
+            for (const change of changes) {
+                const parts = change.value.split(";").map(s => s.trim());
+                
+                const typePart = parts.find(p => p.toLowerCase().startsWith("type:"));
+                const consumePart = parts.find(p => p.toLowerCase().startsWith("consume"));
+                const isOnce = parts.some(p => p.toLowerCase() === "once");
+
+                // Parse consumption target and pre-fetch the item name for the UI
+                let consumeTarget = null;
+                let consumeItemName = null;
+                
+                if (consumePart) {
+                    const split = consumePart.split(":");
+                    consumeTarget = split.length > 1 ? split[1].trim() : "origin";
+                    
+                    if (consumeTarget === "origin" && effect.origin) {
+                        const originParts = effect.origin.split('.');
+                        const itemId = originParts[originParts.length - 1];
+                        const item = actor.items.get(itemId);
+                        if (item) {
+                            consumeItemName = item.name;
+                        } else {
+                            const originDoc = await fromUuid(effect.origin);
+                            if (originDoc && originDoc.documentName === "Item") consumeItemName = originDoc.name;
+                            else consumeItemName = "Origin Item";
+                        }
+                    } else if (consumeTarget !== "origin") {
+                        const item = actor.items.get(consumeTarget) || actor.items.find(i => i.name === consumeTarget);
+                        if (item) consumeItemName = item.name;
+                        else consumeItemName = consumeTarget; // Fallback to raw string
+                    }
+                }
+
+                // Isolate the formula
+                const formulaParts = parts.filter(p => 
+                    !p.toLowerCase().startsWith("type:") && 
+                    !p.toLowerCase().startsWith("consume") && 
+                    p.toLowerCase() !== "once"
+                );
+                
+                let rawFormula = formulaParts.length > 0 ? formulaParts[0] : "0";
+                const resolvedFormula = this._resolveFormula(rawFormula, rollData);
+
+                let allowedTypes = ["any"];
+                if (typePart) {
+                    const typeString = typePart.split(":")[1];
+                    allowedTypes = typeString.split(",").map(t => t.trim().toLowerCase());
+                }
+
+                let isMatch = false;
+                for (const allowedType of allowedTypes) {
+                    if (allowedType === "all" || allowedType === "any") isMatch = true;
+                    else if (allowedType === type) isMatch = true;
+                    else if (allowedType === "check") {
+                        if (["skill", "tool", "ability", "check", "initiative"].includes(type)) isMatch = true;
+                    }
+                    else if (allowedType === "save") {
+                        if (["save", "death", "concentration"].includes(type)) isMatch = true;
+                    }
+                    else if (type === "check" && ["skill", "tool", "initiative"].includes(allowedType)) isMatch = true;
+                    else if (allowedType === "attack" && type === "attack") isMatch = true;
+                    else if (allowedType === "damage" && type === "damage") isMatch = true;
+
+                    if (isMatch) break;
+                }
+                
+                if (isMatch) {
+                    bonuses.push({
+                        effectId: effect.id,
+                        origin: effect.origin,
+                        name: effect.name,
+                        icon: effect.img || effect.icon || "icons/svg/aura.svg",
+                        rawFormula: rawFormula,
+                        resolvedFormula: resolvedFormula,
+                        isOnce: isOnce,
+                        consumeTarget: consumeTarget,
+                        consumeItemName: consumeItemName // Sent to the UI
+                    });
+                }
+            }
+        }
+
+        // --- 3. RENDER APPLICATION V2 SELECTOR ---
+        new BonusSelector({
+            bonuses: bonuses,
+            type: type,
+            isCritDefault: isOriginalCrit,
+            onSubmit: async (result) => {
+                let bonusDef;
+                
+                if (result.isCustom) {
+                    bonusDef = {
+                        name: "Custom Bonus",
+                        rawFormula: result.formula,
+                        isOnce: false 
+                    };
+                } else {
+                    bonusDef = bonuses[result.index];
+                }
+
+                if (bonusDef) {
+                    await this.applyBonus(message, type, bonusDef, actor, result.applyCrit);
+                }
+            }
+        }).render(true);
+    }
+
+    static async applyBonus(message, type, bonusDef, actor, applyCrit = false) {
+        try {
+            // --- HANDLE CONSUMPTION FIRST ---
+            if (bonusDef.consumeTarget) {
+                let itemToConsume = null;
+
+                if (bonusDef.consumeTarget === "origin" && bonusDef.origin) {
+                    // Extract the Item ID from the end of the origin UUID
+                    const parts = bonusDef.origin.split('.');
+                    const itemId = parts[parts.length - 1];
+                    
+                    // Directly fetch the item from the specific token/actor making the roll
+                    itemToConsume = actor.items.get(itemId);
+                    
+                    // Fallback to name-matching if ID fails for any reason
+                    if (!itemToConsume) {
+                        const originDoc = await fromUuid(bonusDef.origin);
+                        if (originDoc && originDoc.documentName === "Item") {
+                            itemToConsume = actor.items.find(i => i.name === originDoc.name);
+                        }
+                    }
+                } else if (bonusDef.consumeTarget !== "origin") {
+                    itemToConsume = actor.items.get(bonusDef.consumeTarget) || actor.items.find(i => i.name === bonusDef.consumeTarget);
+                }
+
+                if (itemToConsume) {
+                    const uses = itemToConsume.system?.uses;
+                    
+                    // Modern D&D5e (v3.0+) check: uses 'spent' instead of 'value'
+                    if (uses && uses.max) {
+                        const remaining = uses.value; 
+                        const spent = uses.spent || 0; 
+
+                        if (remaining > 0) {
+                            await itemToConsume.update({"system.uses.spent": spent + 1});
+                            ui.notifications.info(`Consumed 1 use from ${itemToConsume.name}.`);
+                        } else {
+                            return ui.notifications.warn(`Cannot apply bonus: ${itemToConsume.name} has no uses left!`);
+                        }
+                    } else {
+                        ui.notifications.warn(`${itemToConsume.name} has no uses configured.`);
+                    }
+                } else {
+                    return ui.notifications.error(`Could not find the target item to consume uses from.`);
+                }
+            }
+
+            // --- FIND TARGET ROLL FIRST TO INHERIT CONFIGURATION ---
+            let targetRollIndex = -1;
+            if (type === "damage") {
+                targetRollIndex = message.rolls.findIndex(r => r instanceof CONFIG.Dice.DamageRoll);
+            } else {
+                targetRollIndex = message.rolls.findIndex(r => r instanceof CONFIG.Dice.D20Roll);
+            }
+
+            if (targetRollIndex === -1) {
+                if (message.rolls.length > 0) targetRollIndex = 0;
+                else return ui.notifications.error("Could not find target roll in message.");
+            }
+
+            const originalRoll = message.rolls[targetRollIndex];
+            const TargetRollClass = originalRoll.constructor;
+            
+            // Clone the original roll's options to prevent the mergeObject error
+            let rollOptions = foundry.utils.deepClone(originalRoll.options) || {};
+
+            // --- EVALUATE FORMULA ---
+            const rollData = actor.getRollData();
+            const cleanFormula = this._resolveFormula(bonusDef.rawFormula, rollData);
+            
+            if (!cleanFormula || cleanFormula.trim() === "") {
+                return ui.notifications.warn("Invalid bonus formula.");
+            }
+
+            // --- CRIT HANDLING ---
+            if (type === "damage" && applyCrit) {
+                rollOptions.critical = true;
+                rollOptions.multiplyNumeric = game.settings.get("dnd5e", "criticalDamageModifiers") ?? false;
+                rollOptions.maximizeCritical = game.settings.get("dnd5e", "criticalDamageMaxDice") ?? false;
+            }
+
+            // Create the bonus roll securely using the inherited options
+            const bonusRoll = new TargetRollClass(cleanFormula, rollData, rollOptions);
+            await bonusRoll.evaluate();
+
+            const originalTerms = originalRoll.terms.map(t => foundry.utils.deepClone(t));
+            const newTerms = [
+                ...originalTerms,
+                new foundry.dice.terms.OperatorTerm({operator: "+"}),
+                ...bonusRoll.terms
+            ];
+
+            const newRoll = TargetRollClass.fromTerms(newTerms);
+            newRoll.options = rollOptions; 
+            newRoll._total = originalRoll.total + bonusRoll.total;
+            newRoll._evaluated = true; 
+
+            const rolls = [...message.rolls];
+            rolls[targetRollIndex] = newRoll;
+
+            if (message.flags["rsr5e"]) {
+                await message.update({ rolls: rolls });
+            } else {
+                const newContent = await newRoll.render();
+                await message.update({ rolls: rolls, content: newContent });
+            }
+
+            if (type === "initiative") {
+                const messageSceneId = message.speaker.scene;
+                const targetCombat = game.combats.find(c => c.scene?.id === messageSceneId) || game.combat;
+                if (targetCombat) {
+                    const combatant = targetCombat.combatants.find(c => 
+                        (c.tokenId && c.tokenId === message.speaker.token) || 
+                        (c.actorId && c.actorId === message.speaker.actor)
+                    );
+                    if (combatant) await targetCombat.setInitiative(combatant.id, newRoll.total);
+                }
+            }
+
+            // Clean up if it was a one-time effect
+            if (bonusDef.isOnce && bonusDef.effectId) {
+                const effect = actor.effects.get(bonusDef.effectId);
+                if (effect) await effect.delete();
+            }
+            ui.notifications.info(`Applied ${bonusDef.name} (+${bonusRoll.total}).`);
+
+        } catch (err) {
+            console.error("RSR Addon | Error applying bonus:", err);
+            ui.notifications.error(`Error applying bonus: ${err.message}`);
+        }
+    }
+
+    static _resolveFormula(formula, rollData, logging = false) {
+        if (!formula || typeof formula !== 'string' || !formula.includes("@")) return formula;
+        
+        return formula.replace(/@([a-zA-Z0-9._-]+)/g, (match, term) => {
+            let value = foundry.utils.getProperty(rollData, term);
+            if (value === undefined) return match;
+
+            if (typeof value === 'object' && value !== null) {
+                if ('number' in value && 'faces' in value) return `${value.number}d${value.faces}`;
+                if ('number' in value && 'die' in value) return `${value.number}${value.die}`;
+                if ('value' in value) return value.value;
+                if ('total' in value) return value.total;
+                if ('formula' in value) return value.formula;
+                return "0"; 
+            }
+            return String(value);
+        });
+    }
+}
+
+// ==========================================================
+//  APPLICATION V2 CLASS
+// ==========================================================
+class BonusSelector extends ApplicationV2 {
+    constructor(options) {
+        super(options);
+        this.bonuses = options.bonuses;
+        this.type = options.type;
+        this.isCritDefault = options.isCritDefault || false; 
+        this.onSubmitCallback = options.onSubmit;
+    }
+
+    static DEFAULT_OPTIONS = {
+        tag: "form",
+        id: "rsr-bonus-selector",
+        classes: ["rsr-bonus-window"],
+        window: {
+            title: "Apply Retroactive Bonus",
+            icon: "fas fa-dice-d20",
+            resizable: false,
+            width: 440
+        },
+        position: {
+            width: 440,
+            height: "auto"
+        },
+        form: {
+            handler: BonusSelector.prototype._handleSubmit,
+            closeOnSubmit: true
+        }
+    };
+
+    async _renderHTML(context, options) {
+        let html = `
+        <div class="rsr-bonus-content" style="padding: 10px; display: flex; flex-direction: column; gap: 10px;">
+            <p style="margin: 0; color: var(--color-text-primary);">
+                Select a bonus to apply to the <strong>${this.type} roll</strong>:
+            </p>
+            <div class="rsr-bonus-list" style="display: flex; flex-direction: column; gap: 6px;">
+        `;
+
+        const customIcon = "icons/magic/life/crosses-trio-red.webp";
+        const customChecked = this.bonuses.length === 0 ? "checked" : "";
+        
+        html += `
+            <div class="form-group" style="display:flex; flex-direction: column; padding: 8px; border: 1px solid var(--color-border-light-2); border-radius: 4px; background: var(--color-bg-light);">
+                <div style="display:flex; align-items:center;">
+                    <input type="radio" name="bonusIndex" value="custom" id="bonus-custom" ${customChecked} style="margin-right: 12px;">
+                    <label for="bonus-custom" style="display:flex; align-items:center; cursor:pointer; flex:1; margin:0; user-select: none;">
+                        <img src="${customIcon}" width="32" height="32" style="border:none; margin-right:12px; flex-shrink:0;">
+                        <span style="font-weight:bold; font-size: 1.1em; color: var(--color-text-primary);">Custom Bonus</span>
+                    </label>
+                </div>
+                
+                <div class="custom-input-container" style="margin-top: 8px; margin-left: 44px; display: ${customChecked ? 'block' : 'none'};">
+                    <input type="text" name="customFormula" placeholder="e.g. +5 or 1d4" style="width: 100%; box-sizing: border-box; background: var(--color-bg-light); color: var(--color-text-primary); border: 1px solid var(--color-border-dark);">
+                </div>
+            </div>`;
+
+        this.bonuses.forEach((b, i) => {
+            const displayFormula = b.rawFormula !== b.resolvedFormula 
+                ? `${b.rawFormula} ⮕ <strong>${b.resolvedFormula}</strong>` 
+                : b.rawFormula;
+            
+            const checked = (i === 0) ? "checked" : "";
+
+            // Evaluate Consumption badge UI
+            let consumeBadge = "";
+            if (b.consumeItemName) {
+                consumeBadge = `<span style="font-size: 0.85em; color: var(--color-text-danger); display: flex; align-items: center; gap: 4px; margin-top: 2px;">
+                    <i class="fas fa-battery-quarter"></i> Consumes 1 use of ${b.consumeItemName}
+                </span>`;
+            } else if (b.isOnce) {
+                consumeBadge = `<span style="font-size: 0.85em; color: var(--color-text-danger); display: flex; align-items: center; gap: 4px; margin-top: 2px;">
+                    <i class="fas fa-bolt"></i> Consumes this effect
+                </span>`;
+            }
+
+            html += `
+            <div class="form-group" style="display:flex; align-items:center; padding: 8px; border: 1px solid var(--color-border-light-2); border-radius: 4px; background: var(--color-bg-light);">
+                <input type="radio" name="bonusIndex" value="${i}" id="bonus-${i}" ${checked} style="margin-right: 12px;">
+                <label for="bonus-${i}" style="display:flex; align-items:center; cursor:pointer; flex:1; margin:0; user-select: none;">
+                    <img src="${b.icon}" width="32" height="32" style="border:none; margin-right:12px; flex-shrink:0;">
+                    <div style="display:flex; flex-direction:column; justify-content:center;">
+                        <span style="font-weight:bold; font-size: 1.1em; line-height: 1.2; color: var(--color-text-primary);">${b.name}</span>
+                        <span style="font-size:0.9em; color: var(--color-text-secondary);">${displayFormula}</span>
+                        ${consumeBadge}
+                    </div>
+                </label>
+            </div>`;
+        });
+
+        html += `</div>`; 
+
+        if (this.type === "damage") {
+            const critChecked = this.isCritDefault ? "checked" : "";
+            html += `
+            <div class="form-group" style="display:flex; align-items:center; margin-top: 5px; padding: 10px; border: 1px solid var(--color-border-highlight); border-radius: 4px; background: rgba(255, 0, 0, 0.05);">
+                <input type="checkbox" name="applyCrit" id="applyCrit" ${critChecked} style="margin-right: 12px; width: 16px; height: 16px; cursor:pointer;">
+                <label for="applyCrit" style="cursor:pointer; font-weight:bold; color: var(--color-text-primary); margin:0; user-select:none; display:flex; align-items:center;">
+                    <i class="fas fa-bullseye" style="color: var(--color-text-danger); margin-right: 8px;"></i>
+                    Roll as Critical Hit
+                </label>
+            </div>`;
+        }
+
+        html += `
+            <div class="form-footer" style="margin-top: 10px; display: flex; justify-content: flex-end;">
+                <button type="submit" class="save" style="width: auto; min-width: 120px;">
+                    <i class="fas fa-dice-d20"></i> Apply Bonus
+                </button>
+            </div>
+        </div>
+        `;
+
+        const div = document.createElement("div");
+        div.innerHTML = html;
+
+        const customInputContainer = div.querySelector('.custom-input-container');
+        const customInput = div.querySelector('input[name="customFormula"]');
+        const allRadios = div.querySelectorAll('input[name="bonusIndex"]');
+
+        allRadios.forEach(radio => {
+            radio.addEventListener('change', (e) => {
+                if (e.target.value === "custom") {
+                    customInputContainer.style.display = 'block';
+                    customInput.focus();
+                } else {
+                    customInputContainer.style.display = 'none';
+                }
+            });
+        });
+
+        return div;
+    }
+
+    _replaceHTML(result, content, options) {
+        content.replaceChildren(result);
+    }
+
+    async _handleSubmit(event, form, formData) {
+        const indexValue = formData.object.bonusIndex;
+        const customFormula = formData.object.customFormula;
+        const applyCrit = formData.object.applyCrit === true || formData.object.applyCrit === "on";
+
+        if (this.onSubmitCallback) {
+            if (indexValue === "custom") {
+                if (!customFormula || customFormula.trim() === "") {
+                    return ui.notifications.warn("Please enter a custom bonus formula.");
+                }
+                
+                await this.onSubmitCallback({
+                    isCustom: true,
+                    formula: customFormula,
+                    applyCrit: applyCrit
+                });
+            } else if (indexValue !== undefined) {
+                await this.onSubmitCallback({
+                    isCustom: false,
+                    index: parseInt(indexValue),
+                    applyCrit: applyCrit
+                });
+            }
+        }
+    }
+}

--- a/src/utils/reroll.js
+++ b/src/utils/reroll.js
@@ -1,550 +1,121 @@
-import { RerollManager } from "./reroll.js";
+import { MODULE_SHORT } from "../module/const.js";
+import { ROLL_TYPE } from "./roll.js";
+import { SETTING_NAMES, SettingsUtility } from "./settings.js";
 
-// Import V2 API
-const { ApplicationV2 } = foundry.applications.api;
-
-export class BonusManager {
-    static init(message, html) {
-        const $html = html instanceof HTMLElement ? $(html) : html;
-
-        if (!message.isAuthor && !game.user.isGM) return false;
-        if (!$html || $html.length === 0) return false;
-
-        $html.find('.rsr-damage-buttons button, .rsr-damage-buttons-xl button')
-            .off('click.rsrFix')
-            .on('click.rsrFix', (ev) => {
-                ev.stopPropagation();
-            });
-
-        // --- DETECT SECTIONS ---
-        const hasAttackSection = $html.find('.rsr-section-attack').length > 0;
-        const hasDamageSection = $html.find('.rsr-section-damage').length > 0;
-
-        const isDnd5eRoll = !!message.flags.dnd5e?.roll?.type;
-        const isInitiative = message.flags.core?.initiativeRoll || 
-                             (message.flavor && message.flavor.includes("Initiative")) ||
-                             $html.find('.dice-flavor').text().includes("Initiative");
-
-        if (!hasAttackSection && !hasDamageSection && !isDnd5eRoll && !isInitiative) return false;
-
-        let injected = false;
-
-        // --- INJECT BUTTONS ---
-        if (hasAttackSection) {
-            this.injectButton(message, $html, "attack", ".rsr-section-attack");
-            injected = true;
-        }
-        
-        if (hasDamageSection) {
-            this.injectButton(message, $html, "damage", ".rsr-section-damage");
-            injected = true;
-        }
-
-        let rollType = null;
-        if (isInitiative) rollType = "initiative";
-        else if (isDnd5eRoll) rollType = message.flags.dnd5e.roll.type;
-
-        const validTypes = ["skill", "tool", "ability", "save", "death", "concentration", "initiative"];
-
-        if (rollType && validTypes.includes(rollType)) {
-            const label = rollType === "ability" ? "check" : rollType;
-            this.injectButton(message, $html, label, ".message-header");
-            injected = true;
-        }
-
-        return injected;
-    }
-
-    static injectButton(message, html, type, sectionSelector) {
-        const section = html.find(sectionSelector);
-        if (section.length === 0) return;
-
-        if (section.find(`.rsr-addon-bonus-btn[data-type="${type}"]`).length > 0) return;
-
-        let container = section.find('.rsr-header .rsr-title').first();
-        if (container.length === 0) container = section.find('.rsr-header').first();
-        if (container.length === 0) container = section.find('.message-sender').first(); 
-        if (container.length === 0) container = section; 
-
-        const titleType = type.charAt(0).toUpperCase() + type.slice(1);
-        const btn = $(`<i class="fas fa-plus-circle rsr-addon-bonus-btn" data-type="${type}" title="Add Bonus to ${titleType}"></i>`);
-        
-        if (sectionSelector === ".message-header") {
-            btn.css({ "margin-left": "8px", "align-self": "center", "font-size": "1.2em", "order": "10", "cursor": "pointer" });
-            section.append(btn);
-        } else {
-            container.append(btn);
-        }
-        
-        btn.click((ev) => {
-            ev.preventDefault();
-            ev.stopPropagation(); 
-            this.openBonusDialog(message, type);
-        });
-    }
-
-    static async openBonusDialog(message, type) {
-        let actor = null;
-        if (message.speaker.token) {
-            const token = game.scenes.get(message.speaker.scene)?.tokens.get(message.speaker.token);
-            actor = token?.actor;
-        } else if (message.speaker.actor) {
-            actor = game.actors.get(message.speaker.actor);
-        }
-
-        if (!actor) return ui.notifications.warn("No actor found for this message.");
-        
-        const rollData = actor.getRollData();
-        const bonuses = [];
-
-        // --- Auto-Detect if the original roll was a Crit ---
-        let isOriginalCrit = false;
-        if (type === "damage") {
-            const dmgRoll = message.rolls.find(r => r instanceof CONFIG.Dice.DamageRoll || r.options?.critical !== undefined);
-            if (dmgRoll) {
-                isOriginalCrit = dmgRoll.options?.critical === true || 
-                                 dmgRoll.options?.isCritical === true || 
-                                 message.flags?.dnd5e?.roll?.isCritical === true;
-            }
-        }
-
-        // --- 1. COLLECT CANDIDATE EFFECTS (Active Effects Only) ---
-        const candidateEffects = [];
-        const actorEffects = actor.appliedEffects || actor.effects; 
-        
-        actorEffects.forEach(e => {
-            if (!e.disabled && !e.isSuppressed) {
-                candidateEffects.push({ effect: e, source: "Actor" });
-            }
-        });
-
-        // --- 2. PROCESS EFFECTS ---
-        for (const entry of candidateEffects) {
-            const effect = entry.effect;
-            const changes = effect.changes.filter(c => c.key.trim() === "flags.rsr5e-addon.bonus");
+/**
+ * Utility class to handle rerolling and fudging individual dice on the canvas.
+ */
+export class RerollManager {
+    static registerGlobalListener() {
+        // Listen for clicks on the document to catch dice result interactions
+        $(document).on("mousedown", ".dice-tooltip .dice-rolls .roll.die", (event) => {
+            if (!SettingsUtility.getSettingValue(SETTING_NAMES.REROLL_EVERYONE)) return;
             
-            for (const change of changes) {
-                const parts = change.value.split(";").map(s => s.trim());
-                
-                const typePart = parts.find(p => p.toLowerCase().startsWith("type:"));
-                const consumePart = parts.find(p => p.toLowerCase().startsWith("consume"));
-                const isOnce = parts.some(p => p.toLowerCase() === "once");
+            const dieElement = $(event.currentTarget);
+            const messageElement = dieElement.closest(".chat-message");
+            const messageId = messageElement.data("messageId");
+            const message = game.messages.get(messageId);
 
-                // Parse consumption target and pre-fetch the item name for the UI
-                let consumeTarget = null;
-                let consumeItemName = null;
-                
-                if (consumePart) {
-                    const split = consumePart.split(":");
-                    consumeTarget = split.length > 1 ? split[1].trim() : "origin";
-                    
-                    if (consumeTarget === "origin" && effect.origin) {
-                        const originParts = effect.origin.split('.');
-                        const itemId = originParts[originParts.length - 1];
-                        const item = actor.items.get(itemId);
-                        if (item) {
-                            consumeItemName = item.name;
-                        } else {
-                            const originDoc = await fromUuid(effect.origin);
-                            if (originDoc && originDoc.documentName === "Item") consumeItemName = originDoc.name;
-                            else consumeItemName = "Origin Item";
-                        }
-                    } else if (consumeTarget !== "origin") {
-                        const item = actor.items.get(consumeTarget) || actor.items.find(i => i.name === consumeTarget);
-                        if (item) consumeItemName = item.name;
-                        else consumeItemName = consumeTarget; // Fallback to raw string
-                    }
-                }
+            if (!message) return;
 
-                // Isolate the formula
-                const formulaParts = parts.filter(p => 
-                    !p.toLowerCase().startsWith("type:") && 
-                    !p.toLowerCase().startsWith("consume") && 
-                    p.toLowerCase() !== "once"
-                );
-                
-                let rawFormula = formulaParts.length > 0 ? formulaParts[0] : "0";
-                const resolvedFormula = this._resolveFormula(rawFormula, rollData);
-
-                let allowedTypes = ["any"];
-                if (typePart) {
-                    const typeString = typePart.split(":")[1];
-                    allowedTypes = typeString.split(",").map(t => t.trim().toLowerCase());
-                }
-
-                let isMatch = false;
-                for (const allowedType of allowedTypes) {
-                    if (allowedType === "all" || allowedType === "any") isMatch = true;
-                    else if (allowedType === type) isMatch = true;
-                    else if (allowedType === "check") {
-                        if (["skill", "tool", "ability", "check", "initiative"].includes(type)) isMatch = true;
-                    }
-                    else if (allowedType === "save") {
-                        if (["save", "death", "concentration"].includes(type)) isMatch = true;
-                    }
-                    else if (type === "check" && ["skill", "tool", "initiative"].includes(allowedType)) isMatch = true;
-                    else if (allowedType === "attack" && type === "attack") isMatch = true;
-                    else if (allowedType === "damage" && type === "damage") isMatch = true;
-
-                    if (isMatch) break;
-                }
-                
-                if (isMatch) {
-                    bonuses.push({
-                        effectId: effect.id,
-                        origin: effect.origin,
-                        name: effect.name,
-                        icon: effect.img || effect.icon || "icons/svg/aura.svg",
-                        rawFormula: rawFormula,
-                        resolvedFormula: resolvedFormula,
-                        isOnce: isOnce,
-                        consumeTarget: consumeTarget,
-                        consumeItemName: consumeItemName // Sent to the UI
-                    });
-                }
+            // Handle Right-Click (GM Fudge)
+            if (event.button === 2) {
+                if (!game.user.isGM || !SettingsUtility.getSettingValue(SETTING_NAMES.FUDGE_GM)) return;
+                this._handleFudge(message, dieElement);
+            } 
+            // Handle Left-Click (Player/Author Reroll)
+            else if (event.button === 0) {
+                const canReroll = game.user.isGM || 
+                                 (message.isAuthor && SettingsUtility.getSettingValue(SETTING_NAMES.REROLL_PLAYERS));
+                if (!canReroll) return;
+                this._handleReroll(message, dieElement);
             }
-        }
+        });
+    }
 
-        // --- 3. RENDER APPLICATION V2 SELECTOR ---
-        new BonusSelector({
-            bonuses: bonuses,
-            type: type,
-            isCritDefault: isOriginalCrit,
-            onSubmit: async (result) => {
-                let bonusDef;
-                
-                if (result.isCustom) {
-                    bonusDef = {
-                        name: "Custom Bonus",
-                        rawFormula: result.formula,
-                        isOnce: false 
-                    };
-                } else {
-                    bonusDef = bonuses[result.index];
-                }
+    static async _handleReroll(message, dieElement) {
+        const { rollIndex, termIndex, resultIndex } = this._getDiePath(dieElement);
+        const rolls = [...message.rolls];
+        const targetRoll = rolls[rollIndex];
+        const targetTerm = targetRoll.terms[termIndex];
+        
+        // Create a new roll for just one die
+        const newDieRoll = await new Roll(`1d${targetTerm.faces}`).evaluate();
+        const newResult = newDieRoll.dice[0].results[0];
+        
+        // Update the original result
+        targetTerm.results[resultIndex].result = newResult.result;
+        
+        // Re-evaluate modifiers (Advantage/Disadvantage highlighting)
+        this._recalculateModifiers(targetTerm);
 
-                if (bonusDef) {
-                    await this.applyBonus(message, type, bonusDef, actor, result.applyCrit);
+        // Force Foundry to re-evaluate the total
+        targetRoll._total = targetRoll._evaluateTotal();
+        
+        await message.update({ rolls: rolls });
+        ui.notifications.info(`Rerolled die: New result is ${newResult.result}`);
+    }
+
+    static async _handleFudge(message, dieElement) {
+        const { rollIndex, termIndex, resultIndex } = this._getDiePath(dieElement);
+        
+        new Dialog({
+            title: "Fudge Die Result",
+            content: `<input type="number" id="fudge-value" placeholder="Enter new value" autofocus>`,
+            buttons: {
+                fudge: {
+                    label: "Fudge It",
+                    callback: async (html) => {
+                        const newVal = parseInt(html.find("#fudge-value").val());
+                        if (isNaN(newVal)) return;
+
+                        const rolls = [...message.rolls];
+                        const targetRoll = rolls[rollIndex];
+                        const targetTerm = targetRoll.terms[termIndex];
+
+                        targetTerm.results[resultIndex].result = newVal;
+                        
+                        // Re-evaluate modifiers (Advantage/Disadvantage highlighting)
+                        this._recalculateModifiers(targetTerm);
+
+                        targetRoll._total = targetRoll._evaluateTotal();
+
+                        await message.update({ rolls: rolls });
+                    }
                 }
             }
         }).render(true);
     }
 
-    static async applyBonus(message, type, bonusDef, actor, applyCrit = false) {
-        try {
-            // --- HANDLE CONSUMPTION FIRST ---
-            if (bonusDef.consumeTarget) {
-                let itemToConsume = null;
-
-                if (bonusDef.consumeTarget === "origin" && bonusDef.origin) {
-                    // Extract the Item ID from the end of the origin UUID
-                    const parts = bonusDef.origin.split('.');
-                    const itemId = parts[parts.length - 1];
-                    
-                    // Directly fetch the item from the specific token/actor making the roll
-                    itemToConsume = actor.items.get(itemId);
-                    
-                    // Fallback to name-matching if ID fails for any reason
-                    if (!itemToConsume) {
-                        const originDoc = await fromUuid(bonusDef.origin);
-                        if (originDoc && originDoc.documentName === "Item") {
-                            itemToConsume = actor.items.find(i => i.name === originDoc.name);
-                        }
-                    }
-                } else if (bonusDef.consumeTarget !== "origin") {
-                    itemToConsume = actor.items.get(bonusDef.consumeTarget) || actor.items.find(i => i.name === bonusDef.consumeTarget);
-                }
-
-                if (itemToConsume) {
-                    const uses = itemToConsume.system?.uses;
-                    
-                    // Modern D&D5e (v3.0+) check: uses 'spent' instead of 'value'
-                    if (uses && uses.max) {
-                        const remaining = uses.value; 
-                        const spent = uses.spent || 0; 
-
-                        if (remaining > 0) {
-                            await itemToConsume.update({"system.uses.spent": spent + 1});
-                            ui.notifications.info(`Consumed 1 use from ${itemToConsume.name}.`);
-                        } else {
-                            return ui.notifications.warn(`Cannot apply bonus: ${itemToConsume.name} has no uses left!`);
-                        }
-                    } else {
-                        ui.notifications.warn(`${itemToConsume.name} has no uses configured.`);
-                    }
-                } else {
-                    return ui.notifications.error(`Could not find the target item to consume uses from.`);
-                }
-            }
-
-            // --- FIND TARGET ROLL FIRST TO INHERIT CONFIGURATION ---
-            let targetRollIndex = -1;
-            if (type === "damage") {
-                targetRollIndex = message.rolls.findIndex(r => r instanceof CONFIG.Dice.DamageRoll);
-            } else {
-                targetRollIndex = message.rolls.findIndex(r => r instanceof CONFIG.Dice.D20Roll);
-            }
-
-            if (targetRollIndex === -1) {
-                if (message.rolls.length > 0) targetRollIndex = 0;
-                else return ui.notifications.error("Could not find target roll in message.");
-            }
-
-            const originalRoll = message.rolls[targetRollIndex];
-            const TargetRollClass = originalRoll.constructor;
-            
-            // Clone the original roll's options to prevent the mergeObject error
-            let rollOptions = foundry.utils.deepClone(originalRoll.options) || {};
-
-            // --- EVALUATE FORMULA ---
-            const rollData = actor.getRollData();
-            const cleanFormula = this._resolveFormula(bonusDef.rawFormula, rollData);
-            
-            if (!cleanFormula || cleanFormula.trim() === "") {
-                return ui.notifications.warn("Invalid bonus formula.");
-            }
-
-            // --- CRIT HANDLING ---
-            if (type === "damage" && applyCrit) {
-                rollOptions.critical = true;
-                rollOptions.multiplyNumeric = game.settings.get("dnd5e", "criticalDamageModifiers") ?? false;
-                rollOptions.maximizeCritical = game.settings.get("dnd5e", "criticalDamageMaxDice") ?? false;
-            }
-
-            // Create the bonus roll securely using the inherited options
-            const bonusRoll = new TargetRollClass(cleanFormula, rollData, rollOptions);
-            await bonusRoll.evaluate();
-
-            const originalTerms = originalRoll.terms.map(t => foundry.utils.deepClone(t));
-            const newTerms = [
-                ...originalTerms,
-                new foundry.dice.terms.OperatorTerm({operator: "+"}),
-                ...bonusRoll.terms
-            ];
-
-            const newRoll = TargetRollClass.fromTerms(newTerms);
-            newRoll.options = rollOptions; 
-            newRoll._total = originalRoll.total + bonusRoll.total;
-            newRoll._evaluated = true; 
-
-            const rolls = [...message.rolls];
-            rolls[targetRollIndex] = newRoll;
-
-            if (message.flags["rsr5e"]) {
-                await message.update({ rolls: rolls });
-            } else {
-                const newContent = await newRoll.render();
-                await message.update({ rolls: rolls, content: newContent });
-            }
-
-            if (type === "initiative") {
-                const messageSceneId = message.speaker.scene;
-                const targetCombat = game.combats.find(c => c.scene?.id === messageSceneId) || game.combat;
-                if (targetCombat) {
-                    const combatant = targetCombat.combatants.find(c => 
-                        (c.tokenId && c.tokenId === message.speaker.token) || 
-                        (c.actorId && c.actorId === message.speaker.actor)
-                    );
-                    if (combatant) await targetCombat.setInitiative(combatant.id, newRoll.total);
-                }
-            }
-
-            // Clean up if it was a one-time effect
-            if (bonusDef.isOnce && bonusDef.effectId) {
-                const effect = actor.effects.get(bonusDef.effectId);
-                if (effect) await effect.delete();
-            }
-            ui.notifications.info(`Applied ${bonusDef.name} (+${bonusRoll.total}).`);
-
-        } catch (err) {
-            console.error("RSR Addon | Error applying bonus:", err);
-            ui.notifications.error(`Error applying bonus: ${err.message}`);
-        }
-    }
-
-    static _resolveFormula(formula, rollData, logging = false) {
-        if (!formula || typeof formula !== 'string' || !formula.includes("@")) return formula;
-        
-        return formula.replace(/@([a-zA-Z0-9._-]+)/g, (match, term) => {
-            let value = foundry.utils.getProperty(rollData, term);
-            if (value === undefined) return match;
-
-            if (typeof value === 'object' && value !== null) {
-                if ('number' in value && 'faces' in value) return `${value.number}d${value.faces}`;
-                if ('number' in value && 'die' in value) return `${value.number}${value.die}`;
-                if ('value' in value) return value.value;
-                if ('total' in value) return value.total;
-                if ('formula' in value) return value.formula;
-                return "0"; 
-            }
-            return String(value);
-        });
-    }
-}
-
-// ==========================================================
-//  APPLICATION V2 CLASS
-// ==========================================================
-class BonusSelector extends ApplicationV2 {
-    constructor(options) {
-        super(options);
-        this.bonuses = options.bonuses;
-        this.type = options.type;
-        this.isCritDefault = options.isCritDefault || false; 
-        this.onSubmitCallback = options.onSubmit;
-    }
-
-    static DEFAULT_OPTIONS = {
-        tag: "form",
-        id: "rsr-bonus-selector",
-        classes: ["rsr-bonus-window"],
-        window: {
-            title: "Apply Retroactive Bonus",
-            icon: "fas fa-dice-d20",
-            resizable: false,
-            width: 440
-        },
-        position: {
-            width: 440,
-            height: "auto"
-        },
-        form: {
-            handler: BonusSelector.prototype._handleSubmit,
-            closeOnSubmit: true
-        }
-    };
-
-    async _renderHTML(context, options) {
-        let html = `
-        <div class="rsr-bonus-content" style="padding: 10px; display: flex; flex-direction: column; gap: 10px;">
-            <p style="margin: 0; color: var(--color-text-primary);">
-                Select a bonus to apply to the <strong>${this.type} roll</strong>:
-            </p>
-            <div class="rsr-bonus-list" style="display: flex; flex-direction: column; gap: 6px;">
-        `;
-
-        const customIcon = "icons/magic/life/crosses-trio-red.webp";
-        const customChecked = this.bonuses.length === 0 ? "checked" : "";
-        
-        html += `
-            <div class="form-group" style="display:flex; flex-direction: column; padding: 8px; border: 1px solid var(--color-border-light-2); border-radius: 4px; background: var(--color-bg-light);">
-                <div style="display:flex; align-items:center;">
-                    <input type="radio" name="bonusIndex" value="custom" id="bonus-custom" ${customChecked} style="margin-right: 12px;">
-                    <label for="bonus-custom" style="display:flex; align-items:center; cursor:pointer; flex:1; margin:0; user-select: none;">
-                        <img src="${customIcon}" width="32" height="32" style="border:none; margin-right:12px; flex-shrink:0;">
-                        <span style="font-weight:bold; font-size: 1.1em; color: var(--color-text-primary);">Custom Bonus</span>
-                    </label>
-                </div>
-                
-                <div class="custom-input-container" style="margin-top: 8px; margin-left: 44px; display: ${customChecked ? 'block' : 'none'};">
-                    <input type="text" name="customFormula" placeholder="e.g. +5 or 1d4" style="width: 100%; box-sizing: border-box; background: var(--color-bg-light); color: var(--color-text-primary); border: 1px solid var(--color-border-dark);">
-                </div>
-            </div>`;
-
-        this.bonuses.forEach((b, i) => {
-            const displayFormula = b.rawFormula !== b.resolvedFormula 
-                ? `${b.rawFormula} ⮕ <strong>${b.resolvedFormula}</strong>` 
-                : b.rawFormula;
-            
-            const checked = (i === 0) ? "checked" : "";
-
-            // Evaluate Consumption badge UI
-            let consumeBadge = "";
-            if (b.consumeItemName) {
-                consumeBadge = `<span style="font-size: 0.85em; color: var(--color-text-danger); display: flex; align-items: center; gap: 4px; margin-top: 2px;">
-                    <i class="fas fa-battery-quarter"></i> Consumes 1 use of ${b.consumeItemName}
-                </span>`;
-            } else if (b.isOnce) {
-                consumeBadge = `<span style="font-size: 0.85em; color: var(--color-text-danger); display: flex; align-items: center; gap: 4px; margin-top: 2px;">
-                    <i class="fas fa-bolt"></i> Consumes this effect
-                </span>`;
-            }
-
-            html += `
-            <div class="form-group" style="display:flex; align-items:center; padding: 8px; border: 1px solid var(--color-border-light-2); border-radius: 4px; background: var(--color-bg-light);">
-                <input type="radio" name="bonusIndex" value="${i}" id="bonus-${i}" ${checked} style="margin-right: 12px;">
-                <label for="bonus-${i}" style="display:flex; align-items:center; cursor:pointer; flex:1; margin:0; user-select: none;">
-                    <img src="${b.icon}" width="32" height="32" style="border:none; margin-right:12px; flex-shrink:0;">
-                    <div style="display:flex; flex-direction:column; justify-content:center;">
-                        <span style="font-weight:bold; font-size: 1.1em; line-height: 1.2; color: var(--color-text-primary);">${b.name}</span>
-                        <span style="font-size:0.9em; color: var(--color-text-secondary);">${displayFormula}</span>
-                        ${consumeBadge}
-                    </div>
-                </label>
-            </div>`;
-        });
-
-        html += `</div>`; 
-
-        if (this.type === "damage") {
-            const critChecked = this.isCritDefault ? "checked" : "";
-            html += `
-            <div class="form-group" style="display:flex; align-items:center; margin-top: 5px; padding: 10px; border: 1px solid var(--color-border-highlight); border-radius: 4px; background: rgba(255, 0, 0, 0.05);">
-                <input type="checkbox" name="applyCrit" id="applyCrit" ${critChecked} style="margin-right: 12px; width: 16px; height: 16px; cursor:pointer;">
-                <label for="applyCrit" style="cursor:pointer; font-weight:bold; color: var(--color-text-primary); margin:0; user-select:none; display:flex; align-items:center;">
-                    <i class="fas fa-bullseye" style="color: var(--color-text-danger); margin-right: 8px;"></i>
-                    Roll as Critical Hit
-                </label>
-            </div>`;
-        }
-
-        html += `
-            <div class="form-footer" style="margin-top: 10px; display: flex; justify-content: flex-end;">
-                <button type="submit" class="save" style="width: auto; min-width: 120px;">
-                    <i class="fas fa-dice-d20"></i> Apply Bonus
-                </button>
-            </div>
-        </div>
-        `;
-
-        const div = document.createElement("div");
-        div.innerHTML = html;
-
-        const customInputContainer = div.querySelector('.custom-input-container');
-        const customInput = div.querySelector('input[name="customFormula"]');
-        const allRadios = div.querySelectorAll('input[name="bonusIndex"]');
-
-        allRadios.forEach(radio => {
-            radio.addEventListener('change', (e) => {
-                if (e.target.value === "custom") {
-                    customInputContainer.style.display = 'block';
-                    customInput.focus();
-                } else {
-                    customInputContainer.style.display = 'none';
-                }
+    /**
+     * Resets die result states and re-runs Advantage/Disadvantage logic.
+     * @private
+     */
+    static _recalculateModifiers(targetTerm) {
+        if (targetTerm.modifiers.some(m => m.includes("kh") || m.includes("kl"))) {
+            // Reset states so Foundry can re-determine which to discard
+            targetTerm.results.forEach(r => {
+                r.discarded = false;
+                r.active = true;
             });
-        });
-
-        return div;
-    }
-
-    _replaceHTML(result, content, options) {
-        content.replaceChildren(result);
-    }
-
-    async _handleSubmit(event, form, formData) {
-        const indexValue = formData.object.bonusIndex;
-        const customFormula = formData.object.customFormula;
-        const applyCrit = formData.object.applyCrit === true || formData.object.applyCrit === "on";
-
-        if (this.onSubmitCallback) {
-            if (indexValue === "custom") {
-                if (!customFormula || customFormula.trim() === "") {
-                    return ui.notifications.warn("Please enter a custom bonus formula.");
-                }
-                
-                await this.onSubmitCallback({
-                    isCustom: true,
-                    formula: customFormula,
-                    applyCrit: applyCrit
-                });
-            } else if (indexValue !== undefined) {
-                await this.onSubmitCallback({
-                    isCustom: false,
-                    index: parseInt(indexValue),
-                    applyCrit: applyCrit
-                });
-            }
+            // Foundry internal method to re-apply "Keep Highest/Lowest" logic
+            targetTerm._evaluateModifiers();
         }
+    }
+
+    static _getDiePath(dieElement) {
+        // Find the index of the tool-tip part (e.g., separate entries for d20 and constant bonuses)
+        const tooltipPart = dieElement.closest(".tooltip-part");
+        const allParts = dieElement.closest(".dice-tooltip").find(".tooltip-part");
+        const termIndex = allParts.index(tooltipPart);
+
+        // Find the index of the roll (usually 0 for RSR, but helps if multiple rolls exist)
+        const diceRoll = dieElement.closest(".dice-roll");
+        const allDiceRolls = dieElement.closest(".message-content").find(".dice-roll");
+        const rollIndex = Math.max(0, allDiceRolls.index(diceRoll));
+
+        const resultIndex = dieElement.index();
+
+        return { rollIndex, termIndex, resultIndex };
     }
 }

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -24,7 +24,12 @@ export const SETTING_NAMES = {
     APPLY_DAMAGE_TO: "applyDamageTo",
     ALWAYS_ROLL_MULTIROLL: "alwaysRollMulti",
     CONFIRM_RETRO_ADV: "confirmRetroAdv",
-    CONFIRM_RETRO_CRIT: "confirmRetroCrit"
+    CONFIRM_RETRO_CRIT: "confirmRetroCrit",
+    
+    // Addon Settings
+    REROLL_EVERYONE: "rerollEveryone",
+    REROLL_PLAYERS: "rerollPlayers",
+    FUDGE_GM: "fudgeGM"
 }
 
 /**
@@ -128,6 +133,36 @@ export class SettingsUtility {
                 3: CoreUtility.localize(`${MODULE_SHORT}.choices.apply.3`),
                 4: CoreUtility.localize(`${MODULE_SHORT}.choices.apply.4`)
             }
+        });
+
+        // ==========================================
+        // ADDON SETTINGS
+        // ==========================================
+        game.settings.register(MODULE_NAME, SETTING_NAMES.REROLL_EVERYONE, {
+            name: "Enable Rerolling (Global)",
+            hint: "Master switch. If disabled, no one can reroll dice using clicking.",
+            scope: "world",
+            config: true,
+            type: Boolean,
+            default: true
+        });
+
+        game.settings.register(MODULE_NAME, SETTING_NAMES.REROLL_PLAYERS, {
+            name: "Enable Rerolling for Players",
+            hint: "If enabled, players can reroll their own dice (Left-Click).",
+            scope: "world",
+            config: true,
+            type: Boolean,
+            default: false
+        });
+
+        game.settings.register(MODULE_NAME, SETTING_NAMES.FUDGE_GM, {
+            name: "Enable Fudging for GM",
+            hint: "If enabled, the GM can Right-Click a die to manually set its result.",
+            scope: "world",
+            config: true,
+            type: Boolean,
+            default: false
         });
     }
     


### PR DESCRIPTION
Hey @MangoFVTT! Hope things have been going well for you since we last chatted back in February. 

With the recent major updates to Foundry V14 and D&D5e 5.3.0, RSR understandably had a few things break. Since I had some free time, I went ahead and updated the core codebase on my fork to get it fully compatible again, and also folded in those Interactive Dice and Retroactive Bonus features I mentioned.

I'm opening this PR to hand all this work over to you. As you mentioned before, you might prefer to manually rewrite the new features rather than using my AI-assisted (Gemini and Claude) code—which is totally fair! But at the very least, I'm hoping the V14 and 5.3.0 compatibility fixes here will save you a ton of time and get the module running for the community again.

This PR brings the module fully up to date and resolves the following open issues:
* **Resolves #617** 

In my testing at least it all worked on Foundryvtt v14.539 and DnD5e 3.5.0
I did not check backwards compatibility so I marked it as compatible with those new versions only!

Here is a full breakdown of what is included:

### Foundry V14 & D&D5e 5.3.0 Compatibility (Bug Fixes)
The 5.3.0 system update fundamentally changed how activity hooks, rendering, and roll data work. This PR fixes the resulting breakages:
* **Custom Chat Cards Restored**: Hooked into `dnd5e.renderChatMessage` and implemented `processUsageChatMessage` to prevent the new 5.3.0 rendering cycle from instantly overwriting RSR's injected HTML.
* **Hook Overhaul**: Removed the fragile `setTimeout` legacy hook delays. Replaced them with native 5.3.0 methods (`getAssociatedActivity()`, `getAssociatedActor()`) and proper `usageConfig.subsequentActions = false` overrides.
* **Document Validation**: Removed legacy type validations (e.g., forcing `type: "1"`) to comply with Foundry V14's strict `ChatMessage` creation requirements.
* **Damage Dice Targeting**: Updated DOM selectors to target `.basicdie` so damage dice correctly receive pointer events and highlight styles in the new system HTML.
* **Unlinked Tokens**: Fixed a silent error that prevented RSR from resolving actor data for unlinked tokens.
* **Missing Awaits & Race Conditions**: Fixed a race condition ("Sneaky Rerolls") where attack/damage rolls would re-evaluate immediately after appearing in chat, and patched core RSR functions to ensure background activity actions complete in the correct order.
* **V16 Future-Proofing**: Upgraded internal UI prompts to use Foundry's modern `DialogV2` API.

### New Features (Interactive Dice & Retroactive Bonuses)
*(Note: As discussed, these were built with AI assistance. Feel free to discard these commits if you only want the V14/5.3.0 bug fixes!)*
* **Retroactive Bonus Manager**: Injects a Plus (+) icon into roll headers. Clicking this opens a custom dialog allowing users to retroactively add bonuses (like Bless or Bardic Inspiration) or custom formulas to a roll. Includes smart detection for Active Effects and item consumption logic.
* **Interactive Dice (Canvas Rerolls & Fudging)**: Players can now left-click individual die results within the chat tooltip to reroll them. GMs can right-click any die to manually "fudge" it to a specific value.
* **Typed Damage Splitting**: Formulas like `1d8[fire] + 1d4[cold]` are now visually split in the RSR damage section to clearly show damage types.

---

Thanks again for all the work you've put into this module over the years. Feel free to merge the whole thing, cherry-pick the bug fixes, or just use this code as a reference point!